### PR TITLE
split_mps_tensor now receives sim_params as input

### DIFF
--- a/src/mqt/yaqs/core/methods/tdvp.py
+++ b/src/mqt/yaqs/core/methods/tdvp.py
@@ -57,8 +57,7 @@ def split_mps_tensor(
     Args:
         tensor (NDArray[np.complex128]): Input MPS tensor of shape (d0*d1, D0, D2).
         svd_distribution (str): How to distribute singular values ("left", "right", or "sqrt").
-        max_bond : Maximum allowed bond dimension. Defaults to None
-        threshold (float, optional): Singular values below this threshold are discarded. Defaults to 0.
+        sim_params: Simulation parameters containing threshold and max bond dimension
 
     Returns:
         tuple[NDArray[np.complex128], NDArray[np.complex128]]:

--- a/src/mqt/yaqs/core/methods/tdvp.py
+++ b/src/mqt/yaqs/core/methods/tdvp.py
@@ -87,7 +87,7 @@ def split_mps_tensor(
     u_mat, sigma, v_mat = np.linalg.svd(matrix_for_svd, full_matrices=False)
 
     # Truncate singular values below the threshold
-    num_sv = np.sum(sigma > sim_params.threshold)
+    num_sv: int = np.sum(sigma > sim_params.threshold)
     if sim_params.max_bond_dim is not None:
         num_sv = min(num_sv, sim_params.max_bond_dim)
     sigma = sigma[0:num_sv]

--- a/src/mqt/yaqs/core/methods/tdvp.py
+++ b/src/mqt/yaqs/core/methods/tdvp.py
@@ -36,7 +36,8 @@ if TYPE_CHECKING:
 
 
 def split_mps_tensor(
-    tensor: NDArray[np.complex128], svd_distribution: str, threshold: float = 0
+    tensor: NDArray[np.complex128], svd_distribution: str,
+    sim_params: PhysicsSimParams | StrongSimParams | WeakSimParams,
 ) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
     """Split a Matrix Product State (MPS) tensor into two tensors using singular value decomposition (SVD).
 
@@ -56,6 +57,7 @@ def split_mps_tensor(
     Args:
         tensor (NDArray[np.complex128]): Input MPS tensor of shape (d0*d1, D0, D2).
         svd_distribution (str): How to distribute singular values ("left", "right", or "sqrt").
+        max_bond : Maximum allowed bond dimension. Defaults to None
         threshold (float, optional): Singular values below this threshold are discarded. Defaults to 0.
 
     Returns:
@@ -85,8 +87,10 @@ def split_mps_tensor(
     u_mat, sigma, v_mat = np.linalg.svd(matrix_for_svd, full_matrices=False)
 
     # Truncate singular values below the threshold
-    sigma = sigma[sigma > threshold]
-    num_sv = len(sigma)
+    num_sv = np.sum(sigma > sim_params.threshold)
+    if sim_params.max_bond_dim is not None:
+        num_sv = min(num_sv, sim_params.max_bond_dim)
+    sigma = sigma[0:num_sv]
 
     # Truncate U and Vh accordingly
     u_mat = u_mat[:, :num_sv]
@@ -531,7 +535,7 @@ def two_site_tdvp(
             left_blocks[i], right_blocks[i + 1], merged_mpo, merged_tensor, 0.5 * sim_params.dt, numiter_lanczos
         )
         state.tensors[i], state.tensors[i + 1] = split_mps_tensor(
-            merged_tensor, "right", threshold=sim_params.threshold
+            merged_tensor, "right", sim_params
         )
         left_blocks[i + 1] = update_left_environment(
             state.tensors[i], state.tensors[i], hamiltonian.tensors[i], left_blocks[i]
@@ -558,11 +562,11 @@ def two_site_tdvp(
     # Only a single sweep is needed for circuits
     if isinstance(sim_params, (WeakSimParams, StrongSimParams)):
         state.tensors[i], state.tensors[i + 1] = split_mps_tensor(
-            merged_tensor, "right", threshold=sim_params.threshold
+            merged_tensor, "right", sim_params
         )
         return
 
-    state.tensors[i], state.tensors[i + 1] = split_mps_tensor(merged_tensor, "left", threshold=sim_params.threshold)
+    state.tensors[i], state.tensors[i + 1] = split_mps_tensor(merged_tensor, "left", sim_params=sim_params)
     right_blocks[i] = update_right_environment(
         state.tensors[i + 1], state.tensors[i + 1], hamiltonian.tensors[i + 1], right_blocks[i + 1]
     )
@@ -582,7 +586,7 @@ def two_site_tdvp(
         merged_tensor = update_site(
             left_blocks[i], right_blocks[i + 1], merged_mpo, merged_tensor, 0.5 * sim_params.dt, numiter_lanczos
         )
-        state.tensors[i], state.tensors[i + 1] = split_mps_tensor(merged_tensor, "left", threshold=sim_params.threshold)
+        state.tensors[i], state.tensors[i + 1] = split_mps_tensor(merged_tensor, "left", sim_params)
         right_blocks[i] = update_right_environment(
             state.tensors[i + 1], state.tensors[i + 1], hamiltonian.tensors[i + 1], right_blocks[i + 1]
         )

--- a/tests/core/methods/test_tdvp.py
+++ b/tests/core/methods/test_tdvp.py
@@ -60,8 +60,20 @@ def test_split_mps_tensor_left_right_sqrt() -> None:
     The reconstructed tensor is compared to the original A.
     """
     A = rng.random(size=(4, 3, 5))
+    # Placeholder
+    measurements = [Observable("z", site) for site in range(1)]
+    sim_params = PhysicsSimParams(
+        measurements,
+        elapsed_time=0.2,
+        dt=0.1,
+        sample_timesteps=True,
+        num_traj=1,
+        max_bond_dim=100,
+        threshold=1e-8,
+        order=1,
+    )
     for distr in ["left", "right", "sqrt"]:
-        A0, A1 = split_mps_tensor(A, svd_distribution=distr, threshold=1e-8)
+        A0, A1 = split_mps_tensor(A, svd_distribution=distr, sim_params=sim_params)
         # A0 should have shape (2, 3, r) and A1 should have shape (2, r, 5), where r is the effective rank.
         assert A0.ndim == 3
         assert A1.ndim == 3
@@ -82,8 +94,20 @@ def test_split_mps_tensor_invalid_shape() -> None:
     This test creates a tensor A with shape (3, 3, 5) and expects the function to raise an error.
     """
     A = rng.random(size=(3, 3, 5))
+    # Placeholder
+    measurements = [Observable("z", site) for site in range(1)]
+    sim_params = PhysicsSimParams(
+        measurements,
+        elapsed_time=0.2,
+        dt=0.1,
+        sample_timesteps=True,
+        num_traj=1,
+        max_bond_dim=100,
+        threshold=1e-8,
+        order=1,
+    )
     with pytest.raises(ValueError, match=r"The first dimension of the tensor must be divisible by 2."):
-        split_mps_tensor(A, svd_distribution="left")
+        split_mps_tensor(A, svd_distribution="left", sim_params=sim_params)
 
 
 def test_merge_mps_tensors() -> None:


### PR DESCRIPTION
## Description

This pull request changes split_mps_tensor in tdvp.py (particularly for 2TDVP) to receive sim_params as an input. This updates the truncation to consider a max_bond_dim outside of dynamic TDVP.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
