### PR TITLE
MPS.to_vec() renamed and takes qiskit ordering

### DIFF
--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -515,7 +515,7 @@ class MPS:
                     return [i - 1, i]
         return [-1]
 
-    def convert_to_vector(self) -> NDArray[np.complex128]:
+    def to_vec(self) -> NDArray[np.complex128]:
         r"""Converts the MPS to a full state vector representation.
 
         Returns:
@@ -524,6 +524,7 @@ class MPS:
         """
         # Start with the first tensor.
         # Assume each tensor has shape (d, chi_left, chi_right) with chi_left=1 for the first tensor.
+        self.flip_network()
         vec = self.tensors[0]  # shape: (d_1, 1, chi_1)
 
         # Contract sequentially with the remaining tensors.
@@ -535,7 +536,7 @@ class MPS:
             # Reshape to merge all physical indices into one index.
             new_shape = (-1, vec.shape[-1])
             vec = np.reshape(vec, new_shape)
-
+        self.flip_network()
         # At the end, the final bond dimension should be 1.
         vec = np.squeeze(vec, axis=-1)
         # Flatten the resulting multi-index into a one-dimensional state vector.

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -676,9 +676,7 @@ def test_convert_to_vector_fidelity() -> None:
     circ = QuantumCircuit(num_qubits)
     circ.h(0)
     circ.cx(0, 1)
-    state_vector = np.array([0.70710678, 0, 0,
-                            0.70710678, 0, 0,
-                            0, 0])
+    state_vector = np.array([0.70710678, 0, 0, 0.70710678, 0, 0, 0, 0])
 
     # Define the initial state
     state = MPS(num_qubits, state="zeros")
@@ -694,4 +692,4 @@ def test_convert_to_vector_fidelity() -> None:
     simulator.run(state, circ, sim_params, noise_model)
     assert sim_params.output_state is not None
     tdvp_state = sim_params.output_state.to_vec()
-    np.testing.assert_allclose(1, np.abs(np.vdot(state_vector, tdvp_state))**2)
+    np.testing.assert_allclose(1, np.abs(np.vdot(state_vector, tdvp_state)) ** 2)

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -23,6 +23,10 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+from qiskit.circuit import QuantumCircuit
+
+from mqt.yaqs import simulator
+from mqt.yaqs.core.data_structures.simulation_parameters import StrongSimParams
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -651,7 +655,7 @@ def test_convert_to_vector() -> None:
 
         # Create an MPS for the given state.
         mps = MPS(length=Length, state=state_str)
-        psi = mps.convert_to_vector()
+        psi = mps.to_vec()
 
         # Construct the expected state vector as the Kronecker product of local states.
         local_states = [local_state for i in range(Length)]
@@ -661,3 +665,33 @@ def test_convert_to_vector() -> None:
             expected = np.kron(expected, state)
 
         assert np.allclose(psi, expected, atol=tol)
+
+
+def test_convert_to_vector_fidelity() -> None:
+    """Test convert to vector.
+
+    Tests the MPS_to_vector function for a circuit input
+    """
+    num_qubits = 3
+    circ = QuantumCircuit(num_qubits)
+    circ.h(0)
+    circ.cx(0, 1)
+    state_vector = np.array([0.70710678, 0, 0,
+                            0.70710678, 0, 0,
+                            0, 0])
+
+    # Define the initial state
+    state = MPS(num_qubits, state="zeros")
+
+    # Define the simulation parameters
+    N = 1
+    max_bond_dim = 8
+    threshold = 0
+    window_size = 0
+    measurements = [Observable("z", site) for site in range(num_qubits)]
+    sim_params = StrongSimParams(measurements, N, max_bond_dim, threshold, window_size, get_state=True)
+    noise_model = None
+    simulator.run(state, circ, sim_params, noise_model)
+    assert sim_params.output_state is not None
+    tdvp_state = sim_params.output_state.to_vec()
+    np.testing.assert_allclose(1, np.abs(np.vdot(state_vector, tdvp_state))**2)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -190,7 +190,7 @@ def test_strong_simulation_no_noise() -> None:
     simulator.run(state, circ, sim_params, noise_model=None)
     assert sim_params.output_state is not None
     assert isinstance(sim_params.output_state, MPS)
-    sv = sim_params.output_state.convert_to_vector()
+    sv = sim_params.output_state.to_vec()
 
     expected = [0.34870601 + 0.7690227j, 0.03494528 + 0.34828721j, 0.03494528 + 0.34828721j, -0.19159629 - 0.07244828j]
     fidelity = np.abs(np.vdot(sv, expected)) ** 2


### PR DESCRIPTION
## Description

This pull request updates MPS.convert_to_vector() to be named MPS.to_vec() to align with MPO.to_mat() function.
Additionally, the state is flipped before doing so to align with qiskit qubit order.

Tests were added for fidelity of a Bell state.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
