### PR TITLE
Save output state for weak simulation and physics simulation

### DIFF
--- a/src/mqt/yaqs/circuits/circuit_tjm.py
+++ b/src/mqt/yaqs/circuits/circuit_tjm.py
@@ -254,8 +254,6 @@ def circuit_tjm(
                 sim_params.output_state = state
             return state.measure_shots(sim_params.shots)
         # Each shot is an individual trajectory
-        if sim_params.get_state:
-            sim_params.output_state = state
         return state.measure_shots(shots=1)
     # StrongSimParams
     results = np.zeros((len(sim_params.observables), 1))

--- a/src/mqt/yaqs/circuits/circuit_tjm.py
+++ b/src/mqt/yaqs/circuits/circuit_tjm.py
@@ -250,8 +250,12 @@ def circuit_tjm(
     if isinstance(sim_params, WeakSimParams):
         if not noise_model or all(gamma == 0 for gamma in noise_model.strengths):
             # All shots can be done at once in noise-free model
+            if sim_params.get_state:
+                sim_params.output_state = state
             return state.measure_shots(sim_params.shots)
         # Each shot is an individual trajectory
+        if sim_params.get_state:
+            sim_params.output_state = state
         return state.measure_shots(shots=1)
     # StrongSimParams
     results = np.zeros((len(sim_params.observables), 1))

--- a/src/mqt/yaqs/core/data_structures/simulation_parameters.py
+++ b/src/mqt/yaqs/core/data_structures/simulation_parameters.py
@@ -124,12 +124,16 @@ class PhysicsSimParams:
         The threshold value for the simulation (default is 1e-6).
     order : int, optional
         The order of the simulation (default is 1).
+    get_state: bool, optional
+        If True, output MPS is returned.
 
     Methods:
     --------
     aggregate_trajectories() -> None:
         Aggregates the trajectories of the observables by computing their mean.
     """
+
+    output_state: MPS | None = None
 
     def __init__(
         self,
@@ -142,6 +146,7 @@ class PhysicsSimParams:
         order: int = 1,
         *,
         sample_timesteps: bool = True,
+        get_state: bool = False,
     ) -> None:
         """Physics simulation parameters initialization.
 
@@ -165,6 +170,8 @@ class PhysicsSimParams:
             Order of approximation or numerical scheme, by default 1.
         sample_timesteps : bool, optional
             Flag indicating whether to sample at intermediate time steps, by default True.
+        get_state : bool, optional
+            If True, output MPS is returned.
         """
         self.observables = observables
         self.sorted_observables = sorted(observables, key=lambda obs: (obs.site, obs.name))
@@ -176,6 +183,7 @@ class PhysicsSimParams:
         self.max_bond_dim = max_bond_dim
         self.threshold = threshold
         self.order = order
+        self.get_state = get_state
 
     def aggregate_trajectories(self) -> None:
         """Aggregates trajectories for result.
@@ -206,6 +214,8 @@ class WeakSimParams:
         The threshold value for the simulation.
     window_size : int | None
         The window size for the simulation.
+    get_state:
+        If True, output MPS is returned.
 
     Methods:
     --------
@@ -218,8 +228,17 @@ class WeakSimParams:
     # Properties set as placeholders for code compatibility
     dt = 1
     num_traj = 0
+    output_state: MPS | None = None
 
-    def __init__(self, shots: int, max_bond_dim: int = 2, threshold: float = 1e-6, window_size: int | None = 0) -> None:
+    def __init__(
+        self,
+        shots: int,
+        max_bond_dim: int = 2,
+        threshold: float = 1e-6,
+        window_size: int | None = 0,
+        *,
+        get_state: bool = False,
+    ) -> None:
         """Weak circuit simulation initialization.
 
         Initializes parameters for a weak circuit simulation.
@@ -234,12 +253,15 @@ class WeakSimParams:
             Accuracy threshold for truncating tensors, by default 1e-6.
         window_size : int or None, optional
             Window size for the simulation algorithm, by default None.
+        get_state:
+            If True, output MPS is returned.
         """
         self.measurements: list[dict[int, int] | None] = [None] * shots
         self.shots = shots
         self.max_bond_dim = max_bond_dim
         self.threshold = threshold
         self.window_size = window_size
+        self.get_state = get_state
 
     def aggregate_measurements(self) -> None:
         """Aggregates shots into final result.
@@ -296,7 +318,7 @@ class StrongSimParams:
     Methods:
     --------
     __init__(self, observables: list[Observable], num_traj: int = 1000, max_bond_dim: int = 2,
-             threshold: float = 1e-6, window_size: int | None = None) -> None:
+             threshold: float = 1e-6, window_size: int | None = None, get_state: bool = False) -> None:
         Initializes the StrongSimParams with the given parameters.
     aggregate_trajectories(self) -> None:
         Aggregates the trajectories of the observables by computing the mean across all trajectories.

--- a/src/mqt/yaqs/physics/physics_tjm.py
+++ b/src/mqt/yaqs/physics/physics_tjm.py
@@ -142,8 +142,6 @@ def physics_tjm_2(args: tuple[int, MPS, NoiseModel | None, PhysicsSimParams, MPO
         determined by the number of observables and time steps.
     """
     _i, initial_state, noise_model, sim_params, hamiltonian = args
-    if sim_params.get_state:
-        assert not noise_model or all(gamma == 0 for gamma in noise_model.strengths), "Cannot return state in noisy circuit simulation due to stochastics."
 
     state = copy.deepcopy(initial_state)
     if sim_params.sample_timesteps:
@@ -186,8 +184,6 @@ def physics_tjm_1(args: tuple[int, MPS, NoiseModel | None, PhysicsSimParams, MPO
         by the number of observables and time steps.
     """
     _i, initial_state, noise_model, sim_params, hamiltonian = args
-    if sim_params.get_state:
-        assert not noise_model or all(gamma == 0 for gamma in noise_model.strengths), "Cannot return state in noisy circuit simulation due to stochastics."
 
     state = copy.deepcopy(initial_state)
 

--- a/src/mqt/yaqs/physics/physics_tjm.py
+++ b/src/mqt/yaqs/physics/physics_tjm.py
@@ -159,6 +159,9 @@ def physics_tjm_2(args: tuple[int, MPS, NoiseModel | None, PhysicsSimParams, MPO
         if sim_params.sample_timesteps or j == len(sim_params.times) - 1:
             sample(phi, hamiltonian, noise_model, sim_params, results, j)
 
+    if sim_params.get_state:
+        sim_params.output_state = phi
+
     return results
 
 
@@ -209,5 +212,8 @@ def physics_tjm_1(args: tuple[int, MPS, NoiseModel | None, PhysicsSimParams, MPO
         elif j == len(sim_params.times) - 1:
             for obs_index, observable in enumerate(sim_params.sorted_observables):
                 results[obs_index, 0] = copy.deepcopy(state).measure_expectation_value(observable)
+
+    if sim_params.get_state:
+        sim_params.output_state = state
 
     return results

--- a/src/mqt/yaqs/physics/physics_tjm.py
+++ b/src/mqt/yaqs/physics/physics_tjm.py
@@ -184,6 +184,8 @@ def physics_tjm_1(args: tuple[int, MPS, NoiseModel | None, PhysicsSimParams, MPO
         by the number of observables and time steps.
     """
     _i, initial_state, noise_model, sim_params, hamiltonian = args
+    if sim_params.get_state:
+        assert not noise_model or all(gamma == 0 for gamma in noise_model.strengths), "Cannot return state in noisy circuit simulation due to stochastics."
     state = copy.deepcopy(initial_state)
 
     if sim_params.sample_timesteps:

--- a/src/mqt/yaqs/simulator.py
+++ b/src/mqt/yaqs/simulator.py
@@ -131,6 +131,7 @@ def _run_weak_sim(
     else:
         sim_params.num_traj = sim_params.shots
         sim_params.shots = 1
+        assert not sim_params.get_state, "Cannot return state in noisy circuit simulation due to stochastics."
 
     args = [(i, initial_state, noise_model, sim_params, operator) for i in range(sim_params.num_traj)]
     if parallel and sim_params.num_traj > 1:
@@ -205,6 +206,8 @@ def _run_physics(
 
     if not noise_model or all(gamma == 0 for gamma in noise_model.strengths):
         sim_params.num_traj = 1
+    else:
+        assert not sim_params.get_state, "Cannot return state in noisy physics simulation due to stochastics."
 
     for observable in sim_params.sorted_observables:
         observable.initialize(sim_params)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -317,7 +317,7 @@ def test_weak_simulation_get_state() -> None:
 
     circuit = create_ising_circuit(L=num_qubits, J=1, g=0.5, dt=0.1, timesteps=10)
     circuit.measure_all()
-    shots = 1024
+    shots = 1
     max_bond_dim = 4
     threshold = 1e-6
     window_size = 0

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -153,20 +153,25 @@ def test_physics_simulation_get_state() -> None:
         sim_params = PhysicsSimParams(
             measurements,
             elapsed_time,
-            dt, num_traj,
+            dt,
+            num_traj,
             max_bond_dim,
             threshold,
             order,
             sample_timesteps=sample_timesteps,
-            get_state=True
+            get_state=True,
         )
         simulator.run(initial_state, H, sim_params, noise_model=None, parallel=False)
         assert sim_params.output_state is not None
         assert isinstance(sim_params.output_state, MPS)
         sv = sim_params.output_state.to_vec()
 
-        expected = [3.48123000e-01 + 0.76996349j, 0.00000000e+00 + 0.349228j,
-                    0.00000000e+00 + 0.349228j, -1.92179306e-01 - 0.07150749j]
+        expected = [
+            3.48123000e-01 + 0.76996349j,
+            0.00000000e00 + 0.349228j,
+            0.00000000e00 + 0.349228j,
+            -1.92179306e-01 - 0.07150749j,
+        ]
         fidelity = np.abs(np.vdot(sv, expected)) ** 2
         np.testing.assert_allclose(1, fidelity)
 


### PR DESCRIPTION
## Description

This pull request adds an option `get_state` to the classes `WeakSimParams` and `PhysicsSimParams` which, if set to True, saves the resulting statevector in the attribute `output_state`. The implemented functionality is similar to `StrongSimParams`. Also, the docstring is updated and test cases are added to ensure the correct statevector is calculated and that this option is only available if a noise-free simulation is performed.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
