### PR TITLE
Truncation after noise

### DIFF
--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -289,7 +289,7 @@ class MPS:
         if decomposition == "QR":
             site_tensor, bond_tensor = right_qr(tensor)
         elif decomposition == "SVD":
-            site_tensor, s_vec, v_mat = truncated_right_svd(tensor, threshold=1e-12, max_bond_dim=np.inf)
+            site_tensor, s_vec, v_mat = truncated_right_svd(tensor, threshold=1e-12, max_bond_dim=None)
             bond_tensor = np.diag(s_vec) @ v_mat
         self.tensors[current_orthogonality_center] = site_tensor
 
@@ -319,6 +319,7 @@ class MPS:
 
         Args:
             orthogonality_center (int): site of matrix MPS around which we normalize
+            decomposition: Type of decomposition. Default QR.
         """
 
         def sweep_decomposition(orthogonality_center: int, decomposition: str = "QR") -> None:
@@ -358,13 +359,13 @@ class MPS:
         if form == "B":
             self.flip_network()
 
-    def truncate(self, threshold: float=1e-12, max_bond_dim: int | None=int) -> None:
+    def truncate(self, threshold: float = 1e-12, max_bond_dim: int | None = None) -> None:
         """Truncates the MPS in place.
 
         Args:
             state: The MPS.
             sim_params: The truncation parameters.
-            threshold: The truncation threshold. Default 
+            threshold: The truncation threshold. Default
             max_bond_dim: The maximum bond dimension allowed. Default None.
 
         """

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -358,6 +358,30 @@ class MPS:
         if form == "B":
             self.flip_network()
 
+    def truncate(self, threshold: float=1e-12, max_bond_dim: int | None=int) -> None:
+        """Truncates the MPS in place.
+
+        Args:
+            state: The MPS.
+            sim_params: The truncation parameters.
+            threshold: The truncation threshold. Default 
+            max_bond_dim: The maximum bond dimension allowed. Default None.
+
+        """
+        if self.length != 1:
+            for i, tensor in enumerate(self.tensors[:-1]):
+                _, _, v_mat = truncated_right_svd(tensor, threshold, max_bond_dim)
+                # Pull v into left leg of next tensor.
+                new_next = np.tensordot(v_mat, self.tensors[i + 1], axes=(1, 1))
+                new_next = new_next.transpose(1, 0, 2)
+                self.tensors[i + 1] = new_next
+                # Pull v^dag into current tensor.
+                self.tensors[i] = np.tensordot(
+                    self.tensors[i],
+                    v_mat.conj(),  # No transpose, put correct axes instead
+                    axes=(2, 1),
+                )
+
     def scalar_product(self, other: MPS, site: int | None = None) -> np.complex128:
         """Compute the scalar (inner) product between two Matrix Product States (MPS).
 

--- a/src/mqt/yaqs/core/methods/bug.py
+++ b/src/mqt/yaqs/core/methods/bug.py
@@ -172,29 +172,6 @@ def local_update(
     return basis_change_m, new_right_block
 
 
-def truncate(state: MPS, sim_params: PhysicsSimParams | WeakSimParams | StrongSimParams) -> None:
-    """Truncates the MPS in place.
-
-    Args:
-        state: The MPS.
-        sim_params: The truncation parameters.
-
-    """
-    if state.length != 1:
-        for i, tensor in enumerate(state.tensors[:-1]):
-            _, _, v_mat = truncated_right_svd(tensor, sim_params.threshold, sim_params.max_bond_dim)
-            # Pull v into left leg of next tensor.
-            new_next = np.tensordot(v_mat, state.tensors[i + 1], axes=(1, 1))
-            new_next = new_next.transpose(1, 0, 2)
-            state.tensors[i + 1] = new_next
-            # Pull v^dag into current tensor.
-            state.tensors[i] = np.tensordot(
-                state.tensors[i],
-                v_mat.conj(),  # No transpose, put correct axes instead
-                axes=(2, 1),
-            )
-
-
 def bug(
     state: MPS, mpo: MPO, sim_params: PhysicsSimParams | WeakSimParams | StrongSimParams, numiter_lanczos: int = 25
 ) -> None:
@@ -237,4 +214,4 @@ def bug(
     )
     state.tensors[0] = updated_tensor
     # Truncation
-    truncate(state, sim_params)
+    state.truncate(sim_params.threshold, sim_params.max_bond_dim)

--- a/src/mqt/yaqs/core/methods/bug.py
+++ b/src/mqt/yaqs/core/methods/bug.py
@@ -182,7 +182,7 @@ def truncate(state: MPS, sim_params: PhysicsSimParams | WeakSimParams | StrongSi
     """
     if state.length != 1:
         for i, tensor in enumerate(state.tensors[:-1]):
-            _, _, v_mat = truncated_right_svd(tensor, sim_params)
+            _, _, v_mat = truncated_right_svd(tensor, sim_params.threshold, sim_params.max_bond_dim)
             # Pull v into left leg of next tensor.
             new_next = np.tensordot(v_mat, state.tensors[i + 1], axes=(1, 1))
             new_next = new_next.transpose(1, 0, 2)

--- a/src/mqt/yaqs/core/methods/bug.py
+++ b/src/mqt/yaqs/core/methods/bug.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from ..data_structures.simulation_parameters import StrongSimParams, WeakSimParams
-from .decompositions import left_qr, right_qr, truncated_right_svd
+from .decompositions import left_qr, right_qr
 from .tdvp import update_left_environment, update_right_environment, update_site
 
 if TYPE_CHECKING:

--- a/src/mqt/yaqs/core/methods/decompositions.py
+++ b/src/mqt/yaqs/core/methods/decompositions.py
@@ -20,35 +20,35 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 
-def right_qr(ps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
+def right_qr(mps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
     """Right QR.
 
     Performs the QR decomposition of an MPS tensor moving to the right.
 
     Args:
-        ps_tensor: The tensor to be decomposed.
+        mps_tensor: The tensor to be decomposed.
 
     Returns:
         q_tensor: The Q tensor with the left virtual leg and the physical
             leg (phys,left,new).
         r_mat: The R matrix with the right virtual leg (new,right).
     """
-    old_shape = ps_tensor.shape
+    old_shape = mps_tensor.shape
     qr_shape = (old_shape[0] * old_shape[1], old_shape[2])
-    ps_tensor = ps_tensor.reshape(qr_shape)
-    q_mat, r_mat = np.linalg.qr(ps_tensor)
+    mps_tensor = mps_tensor.reshape(qr_shape)
+    q_mat, r_mat = np.linalg.qr(mps_tensor)
     new_shape = (old_shape[0], old_shape[1], -1)
     q_tensor = q_mat.reshape(new_shape)
     return q_tensor, r_mat
 
 
-def left_qr(ps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
+def left_qr(mps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
     """Left QR.
 
     Performs the QR decomposition of an MPS tensor moving to the left.
 
     Args:
-        ps_tensor: The tensor to be decomposed.
+        mps_tensor: The tensor to be decomposed.
 
     Returns:
         q_tensor: The Q tensor with the physical leg and the right virtual
@@ -56,11 +56,11 @@ def left_qr(ps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], 
         r_mat: The R matrix with the left virtual leg (left,new).
 
     """
-    old_shape = ps_tensor.shape
-    ps_tensor = ps_tensor.transpose(0, 2, 1)
+    old_shape = mps_tensor.shape
+    mps_tensor = mps_tensor.transpose(0, 2, 1)
     qr_shape = (old_shape[0] * old_shape[2], old_shape[1])
-    ps_tensor = ps_tensor.reshape(qr_shape)
-    q_mat, r_mat = np.linalg.qr(ps_tensor)
+    mps_tensor = mps_tensor.reshape(qr_shape)
+    q_mat, r_mat = np.linalg.qr(mps_tensor)
     q_tensor = q_mat.reshape((old_shape[0], old_shape[2], -1))
     q_tensor = q_tensor.transpose(0, 2, 1)
     r_mat = r_mat.T
@@ -68,14 +68,14 @@ def left_qr(ps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], 
 
 
 def right_svd(
-    ps_tensor: NDArray[np.complex128],
+    mps_tensor: NDArray[np.complex128],
 ) -> tuple[NDArray[np.complex128], NDArray[np.complex128], NDArray[np.complex128]]:
     """Right SVD.
 
     Performs the singular value decomposition of an MPS tensor.
 
     Args:
-        ps_tensor: The tensor to be decomposed.
+        mps_tensor: The tensor to be decomposed.
 
     Returns:
         NDArray[np.complex128]: The U tensor with the left virtual leg and the physical
@@ -84,17 +84,17 @@ def right_svd(
         NDArray[np.complex128]: The V matrix with the right virtual leg (new,right).
 
     """
-    old_shape = ps_tensor.shape
+    old_shape = mps_tensor.shape
     svd_shape = (old_shape[0] * old_shape[1], old_shape[2])
-    ps_tensor = ps_tensor.reshape(svd_shape)
-    u_mat, s_vec, v_mat = np.linalg.svd(ps_tensor, full_matrices=False)
+    mps_tensor = mps_tensor.reshape(svd_shape)
+    u_mat, s_vec, v_mat = np.linalg.svd(mps_tensor, full_matrices=False)
     new_shape = (old_shape[0], old_shape[1], -1)
     u_tensor = u_mat.reshape(new_shape)
     return u_tensor, s_vec, v_mat
 
 
 def truncated_right_svd(
-    ps_tensor: NDArray[np.complex128],
+    mps_tensor: NDArray[np.complex128],
     threshold: float,
     max_bond_dim: int | None,
 ) -> tuple[NDArray[np.complex128], NDArray[np.complex128], NDArray[np.complex128]]:
@@ -103,7 +103,7 @@ def truncated_right_svd(
     Performs the truncated singular value decomposition of an MPS tensor.
 
     Args:
-        ps_tensor: The tensor to be decomposed.
+        mps_tensor: The tensor to be decomposed.
         threshold: SVD threshold
         max_bond_dim: Maximum bond dimension of MPS
 
@@ -114,7 +114,7 @@ def truncated_right_svd(
         v_mat: The V matrix with the right virtual leg (new,right).
 
     """
-    u_mat, s_vec, v_mat = right_svd(ps_tensor)
+    u_mat, s_vec, v_mat = right_svd(mps_tensor)
     cut_sum = 0
     thresh_sq = threshold**2
     cut_index = 1

--- a/src/mqt/yaqs/core/methods/decompositions.py
+++ b/src/mqt/yaqs/core/methods/decompositions.py
@@ -80,7 +80,7 @@ def right_svd(
 def truncated_right_svd(
     ps_tensor: NDArray[np.complex128],
     threshold: float,
-    max_bond_dim: int,
+    max_bond_dim: int | None,
 ) -> tuple[NDArray[np.complex128], NDArray[np.complex128], NDArray[np.complex128]]:
     """Truncated right SVD.
 
@@ -107,7 +107,8 @@ def truncated_right_svd(
         if cut_sum >= thresh_sq:
             cut_index = len(s_vec) - i
             break
-    cut_index = min(cut_index, max_bond_dim)
+    if max_bond_dim is not None:
+        cut_index = min(cut_index, max_bond_dim)
     u_tensor = u_mat[:, :, :cut_index]
     s_vec = s_vec[:cut_index]
     v_mat = v_mat[:cut_index, :]

--- a/src/mqt/yaqs/core/methods/decompositions.py
+++ b/src/mqt/yaqs/core/methods/decompositions.py
@@ -1,0 +1,112 @@
+import numpy as np
+from typing import TYPE_CHECKING
+from numpy.typing import NDArray
+from ..data_structures.simulation_parameters import PhysicsSimParams, StrongSimParams, WeakSimParams
+
+
+def right_qr(ps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
+    """Right QR.
+
+    Performs the QR decomposition of an MPS tensor moving to the right.
+
+    Args:
+        ps_tensor: The tensor to be decomposed.
+
+    Returns:
+        q_tensor: The Q tensor with the left virtual leg and the physical
+            leg (phys,left,new).
+        r_mat: The R matrix with the right virtual leg (new,right).
+    """
+    old_shape = ps_tensor.shape
+    qr_shape = (old_shape[0] * old_shape[1], old_shape[2])
+    ps_tensor = ps_tensor.reshape(qr_shape)
+    q_mat, r_mat = np.linalg.qr(ps_tensor)
+    new_shape = (old_shape[0], old_shape[1], -1)
+    q_tensor = q_mat.reshape(new_shape)
+    return q_tensor, r_mat
+
+
+def left_qr(ps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:
+    """Left QR.
+
+    Performs the QR decomposition of an MPS tensor moving to the left.
+
+    Args:
+        ps_tensor: The tensor to be decomposed.
+
+    Returns:
+        q_tensor: The Q tensor with the physical leg and the right virtual
+            leg (phys,new,right).
+        r_mat: The R matrix with the left virtual leg (left,new).
+
+    """
+    old_shape = ps_tensor.shape
+    ps_tensor = ps_tensor.transpose(0, 2, 1)
+    qr_shape = (old_shape[0] * old_shape[2], old_shape[1])
+    ps_tensor = ps_tensor.reshape(qr_shape)
+    q_mat, r_mat = np.linalg.qr(ps_tensor)
+    q_tensor = q_mat.reshape((old_shape[0], old_shape[2], -1))
+    q_tensor = q_tensor.transpose(0, 2, 1)
+    r_mat = r_mat.T
+    return q_tensor, r_mat
+
+
+def right_svd(
+    ps_tensor: NDArray[np.complex128],
+) -> tuple[NDArray[np.complex128], NDArray[np.complex128], NDArray[np.complex128]]:
+    """Right SVD.
+
+    Performs the singular value decomposition of an MPS tensor.
+
+    Args:
+        ps_tensor: The tensor to be decomposed.
+
+    Returns:
+        NDArray[np.complex128]: The U tensor with the left virtual leg and the physical
+            leg (phys,left,new).
+        NDArray[np.complex128]: The S vector with the singular values.
+        NDArray[np.complex128]: The V matrix with the right virtual leg (new,right).
+
+    """
+    old_shape = ps_tensor.shape
+    svd_shape = (old_shape[0] * old_shape[1], old_shape[2])
+    ps_tensor = ps_tensor.reshape(svd_shape)
+    u_mat, s_vec, v_mat = np.linalg.svd(ps_tensor, full_matrices=False)
+    new_shape = (old_shape[0], old_shape[1], -1)
+    u_tensor = u_mat.reshape(new_shape)
+    return u_tensor, s_vec, v_mat
+
+
+def truncated_right_svd(
+    ps_tensor: NDArray[np.complex128],
+    sim_params: PhysicsSimParams | StrongSimParams | WeakSimParams,
+) -> tuple[NDArray[np.complex128], NDArray[np.complex128], NDArray[np.complex128]]:
+    """Truncated right SVD.
+
+    Performs the truncated singular value decomposition of an MPS tensor.
+
+    Args:
+        ps_tensor: The tensor to be decomposed.
+        sim_params: Simulation parameters containing threshold and maximum bond dimension
+
+    Returns:
+        u_tensor: The U tensor with the left virtual leg and the physical
+            leg (phys,left,new).
+        s_vec: The S vector with the singular values.
+        v_mat: The V matrix with the right virtual leg (new,right).
+
+    """
+    u_mat, s_vec, v_mat = right_svd(ps_tensor)
+    cut_sum = 0
+    thresh_sq = sim_params.threshold**2
+    cut_index = 1
+    for i, s_val in enumerate(np.flip(s_vec)):
+        cut_sum += s_val**2
+        if cut_sum >= thresh_sq:
+            cut_index = len(s_vec) - i
+            break
+    cut_index = min(cut_index, sim_params.max_bond_dim)
+    u_tensor = u_mat[:, :, :cut_index]
+    s_vec = s_vec[:cut_index]
+    v_mat = v_mat[:cut_index, :]
+    return u_tensor, s_vec, v_mat

--- a/src/mqt/yaqs/core/methods/decompositions.py
+++ b/src/mqt/yaqs/core/methods/decompositions.py
@@ -79,7 +79,8 @@ def right_svd(
 
 def truncated_right_svd(
     ps_tensor: NDArray[np.complex128],
-    sim_params: PhysicsSimParams | StrongSimParams | WeakSimParams,
+    threshold: float,
+    max_bond_dim: int,
 ) -> tuple[NDArray[np.complex128], NDArray[np.complex128], NDArray[np.complex128]]:
     """Truncated right SVD.
 
@@ -87,7 +88,8 @@ def truncated_right_svd(
 
     Args:
         ps_tensor: The tensor to be decomposed.
-        sim_params: Simulation parameters containing threshold and maximum bond dimension
+        threshold: SVD threshold
+        max_bond_dim: Maximum bond dimension of MPS
 
     Returns:
         u_tensor: The U tensor with the left virtual leg and the physical
@@ -98,14 +100,14 @@ def truncated_right_svd(
     """
     u_mat, s_vec, v_mat = right_svd(ps_tensor)
     cut_sum = 0
-    thresh_sq = sim_params.threshold**2
+    thresh_sq = threshold**2
     cut_index = 1
     for i, s_val in enumerate(np.flip(s_vec)):
         cut_sum += s_val**2
         if cut_sum >= thresh_sq:
             cut_index = len(s_vec) - i
             break
-    cut_index = min(cut_index, sim_params.max_bond_dim)
+    cut_index = min(cut_index, max_bond_dim)
     u_tensor = u_mat[:, :, :cut_index]
     s_vec = s_vec[:cut_index]
     v_mat = v_mat[:cut_index, :]

--- a/src/mqt/yaqs/core/methods/decompositions.py
+++ b/src/mqt/yaqs/core/methods/decompositions.py
@@ -1,7 +1,23 @@
-import numpy as np
+# Copyright (c) 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Tensor Network Decompositions.
+
+This module implements left and right moving versions of the QR and SVD decompositions which are used throughout YAQS.
+"""
+
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
-from numpy.typing import NDArray
-from ..data_structures.simulation_parameters import PhysicsSimParams, StrongSimParams, WeakSimParams
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 def right_qr(ps_tensor: NDArray[np.complex128]) -> tuple[NDArray[np.complex128], NDArray[np.complex128]]:

--- a/src/mqt/yaqs/core/methods/stochastic_process.py
+++ b/src/mqt/yaqs/core/methods/stochastic_process.py
@@ -134,5 +134,5 @@ def stochastic_process(state: MPS, noise_model: NoiseModel | None, dt: float) ->
     state.tensors[jump_dict["sites"][choice]] = oe.contract(
         "ab, bcd->acd", jump_operator, state.tensors[jump_dict["sites"][choice]]
     )
-    state.normalize("B")
+    state.normalize("B", decomposition="SVD")
     return state

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -56,6 +56,7 @@ def untranspose_block(mpo_tensor: NDArray[np.complex128]) -> NDArray[np.complex1
     """
     return np.transpose(mpo_tensor, (2, 3, 0, 1))
 
+
 def crandn(
     size: int | tuple[int, ...], *args: int, seed: np.random.Generator | int | None = None
 ) -> NDArray[np.complex128]:
@@ -92,6 +93,7 @@ def random_mps(shapes: list[tuple[int, int, int]]) -> MPS:
     mps = MPS(len(shapes), tensors=tensors)
     mps.normalize()
     return mps
+
 
 rng = np.random.default_rng()
 
@@ -772,6 +774,7 @@ def test_padded_mps_error() -> None:
     mps = MPS(length=length, physical_dimensions=[pdim] * length, pad=2)
     with pytest.raises(ValueError, match=r"Target bond dim must be at least as large as the current bond dim."):
         mps.pad_bond_dimension(1)
+
 
 def test_truncate_no_truncation() -> None:
     """Tests the truncation of an MPS, when no truncation should happen."""

--- a/tests/core/methods/test_bug.py
+++ b/tests/core/methods/test_bug.py
@@ -24,7 +24,6 @@ from mqt.yaqs.core.methods.bug import (
     find_new_q,
     local_update,
     prepare_canonical_site_tensors,
-    truncate,
 )
 from mqt.yaqs.core.methods.decompositions import right_qr
 from mqt.yaqs.core.methods.tdvp import update_left_environment
@@ -248,37 +247,6 @@ def test_local_update() -> None:
     assert len(result) == 2
     assert result[0].shape == (3, 6)
     assert result[1].shape == (6, 4, 6)
-
-
-def test_truncate_no_truncation() -> None:
-    """Tests the truncation of an MPS, when no truncation should happen."""
-    shapes = [(2, 1, 4)] + [(2, 4, 4)] * 3 + [(2, 4, 1)]
-    mps = random_mps(shapes)
-    mps.set_canonical_form(0)
-    ref_mps = deepcopy(mps)
-    trunc_params = PhysicsSimParams(observables=[], elapsed_time=1, threshold=1e-16, max_bond_dim=10)
-    # Perform truncation
-    truncate(mps, trunc_params)
-    # Check that the MPS is unchanged
-    mps.check_if_valid_mps()
-    vector = mps.to_vec()
-    ref_vector = ref_mps.to_vec()
-    assert np.allclose(vector, ref_vector)
-
-
-def test_truncate_truncation() -> None:
-    """Tests the truncation of an MPS, when truncation should happen."""
-    shapes = [(2, 1, 4)] + [(2, 4, 4)] * 3 + [(2, 4, 1)]
-    mps = random_mps(shapes)
-    mps.set_canonical_form(0)
-    trunc_params = PhysicsSimParams(observables=[], elapsed_time=1, threshold=0.1, max_bond_dim=3)
-    # Perform truncation
-    truncate(mps, trunc_params)
-    # Check that the MPS is truncated
-    mps.check_if_valid_mps()
-    for tensor in mps.tensors:
-        assert tensor.shape[1] <= 3
-        assert tensor.shape[2] <= 3
 
 
 def test_bug_single_site() -> None:

--- a/tests/core/methods/test_bug.py
+++ b/tests/core/methods/test_bug.py
@@ -16,20 +16,17 @@ import numpy as np
 from scipy.linalg import expm
 
 from mqt.yaqs.core.data_structures.networks import MPO, MPS
-from mqt.yaqs.core.data_structures.simulation_parameters import Observable, PhysicsSimParams
+from mqt.yaqs.core.data_structures.simulation_parameters import PhysicsSimParams
 from mqt.yaqs.core.methods.bug import (
-    _build_basis_change_tensor,  # noqa: PLC2701
-    _choose_stack_tensor,  # noqa: PLC2701
-    _find_new_q,  # noqa: PLC2701
-    _left_qr,  # noqa: PLC2701
-    _local_update,  # noqa: PLC2701
-    _prepare_canonical_site_tensors,  # noqa: PLC2701
-    _right_qr,  # noqa: PLC2701
-    _right_svd,  # noqa: PLC2701
-    _truncated_right_svd,  # noqa: PLC2701
     bug,
+    build_basis_change_tensor,
+    choose_stack_tensor,
+    find_new_q,
+    local_update,
+    prepare_canonical_site_tensors,
     truncate,
 )
+from mqt.yaqs.core.methods.decompositions import right_qr
 from mqt.yaqs.core.methods.tdvp import update_left_environment
 
 if TYPE_CHECKING:
@@ -90,56 +87,6 @@ def random_mpo(shapes: list[tuple[int, int, int, int]]) -> MPO:
     return mpo
 
 
-def test_right_qr() -> None:
-    """Tests the right qr decomposition.
-
-    Ensures that it produces tensors of the correct shape and a unitary tensor.
-    Also checks that the decomposition is actually the original tensor.
-    """
-    shape = (2, 3, 4)
-    tensor = crandn(shape)
-    q_tensor, r_matrix = _right_qr(tensor)
-    assert q_tensor.ndim == 3
-    assert r_matrix.ndim == 2
-    assert q_tensor.shape[0] == shape[0]
-    assert q_tensor.shape[1] == shape[1]
-    assert r_matrix.shape[1] == shape[2]
-    assert q_tensor.shape[2] == r_matrix.shape[0]
-    # Check that q_tensor is unitary
-    iden = np.eye(q_tensor.shape[2])
-    q_matrix = q_tensor.reshape(q_tensor.shape[0] * q_tensor.shape[1], -1)
-    assert np.allclose(q_matrix.conj().T @ q_matrix, iden)
-    # Check that qr = tensor
-    contr = np.tensordot(q_tensor, r_matrix, axes=(2, 0))
-    assert np.allclose(contr, tensor)
-
-
-def test_left_qr() -> None:
-    """Tests the left qr decomposition.
-
-    Ensures that it produces tensors of the correct shape and a unitary tensor.
-    Also checks that the decomposition is actually the original tensor.
-    """
-    shape = (2, 3, 4)
-    tensor = crandn(shape)
-    q_tensor, r_matrix = _left_qr(tensor)
-    assert q_tensor.ndim == 3
-    assert r_matrix.ndim == 2
-    assert q_tensor.shape[0] == shape[0]
-    assert q_tensor.shape[2] == shape[2]
-    assert r_matrix.shape[0] == shape[1]
-    assert q_tensor.shape[1] == r_matrix.shape[1]
-    # Check that q_tensor is unitary
-    iden = np.eye(q_tensor.shape[1])
-    q_matrix = q_tensor.transpose(0, 2, 1)
-    q_matrix = q_matrix.reshape(-1, q_tensor.shape[1])
-    assert np.allclose(q_matrix.T.conj() @ q_matrix, iden)
-    # Check that qr = tensor
-    contr = np.tensordot(q_tensor, r_matrix, axes=(1, 1))
-    contr = contr.transpose(0, 2, 1)
-    assert np.allclose(contr, tensor)
-
-
 def test_prepare_canonical_site_tensors_single_site() -> None:
     """Tests the preparation for a single site MPS.
 
@@ -152,7 +99,7 @@ def test_prepare_canonical_site_tensors_single_site() -> None:
     mpo_tensor = crandn(2, 2, 1, 1)
     mpo = MPO()
     mpo.init_custom([mpo_tensor])
-    canon_sites, left_envs = _prepare_canonical_site_tensors(mps, mpo)
+    canon_sites, left_envs = prepare_canonical_site_tensors(mps, mpo)
     assert mps.almost_equal(ref_mps)
     assert len(left_envs) == 1
     assert len(canon_sites) == 1
@@ -176,7 +123,7 @@ def test_prepare_canonical_site_tensors_three_sites() -> None:
     mpo_tensors = [crandn(shape) for shape in shapes2]
     mpo = MPO()
     mpo.init_custom(mpo_tensors, transpose=False)
-    canon_sites, left_envs = _prepare_canonical_site_tensors(mps, mpo)
+    canon_sites, left_envs = prepare_canonical_site_tensors(mps, mpo)
     assert mps.almost_equal(ref_mps)
     assert len(left_envs) == 3
     assert len(canon_sites) == 3
@@ -187,13 +134,13 @@ def test_prepare_canonical_site_tensors_three_sites() -> None:
     assert np.allclose(correct_env, left_envs[0])
     assert np.allclose(correct_canon, canon_sites[0])
     # Site 1
-    q_last, r_matrix = _right_qr(mps_tensors[0])
+    q_last, r_matrix = right_qr(mps_tensors[0])
     correct_canon = np.tensordot(r_matrix, mps_tensors[1], axes=(1, 1)).transpose(1, 0, 2)
     correct_env = update_left_environment(q_last, q_last, mpo_tensors[0], left_envs[0])
     assert np.allclose(correct_env, left_envs[1])
     assert np.allclose(correct_canon, canon_sites[1])
     # Site 2
-    q_last, r_matrix = _right_qr(correct_canon)
+    q_last, r_matrix = right_qr(correct_canon)
     correct_canon = np.tensordot(r_matrix, mps_tensors[2], axes=(1, 1)).transpose(1, 0, 2)
     correct_env = update_left_environment(q_last, q_last, mpo_tensors[1], left_envs[1])
     assert np.allclose(correct_env, left_envs[2])
@@ -211,7 +158,7 @@ def test_choose_stack_tensor_last_site() -> None:
     mps = MPS(num_sites, tensors=mps_tensors)
     canon_center_tensors = [crandn(2, 3, 4) for _ in range(num_sites)]
     # Found tensor
-    found_tensor = _choose_stack_tensor(num_sites - 1, canon_center_tensors, mps)
+    found_tensor = choose_stack_tensor(num_sites - 1, canon_center_tensors, mps)
     assert np.allclose(mps_tensors[-1], found_tensor)
 
 
@@ -226,7 +173,7 @@ def test_choose_stack_tensor_middle_site() -> None:
     mps = MPS(num_sites, tensors=mps_tensors)
     canon_center_tensors = [crandn(2, 3, 4) for _ in range(num_sites)]
     # Found tensor
-    found_tensor = _choose_stack_tensor(1, canon_center_tensors, mps)
+    found_tensor = choose_stack_tensor(1, canon_center_tensors, mps)
     assert np.allclose(canon_center_tensors[1], found_tensor)
 
 
@@ -238,7 +185,7 @@ def test_find_new_q() -> None:
     """
     old_tensor = crandn(2, 3, 5)
     new_tensor = crandn(2, 4, 5)
-    q_tensor = _find_new_q(old_tensor, new_tensor)
+    q_tensor = find_new_q(old_tensor, new_tensor)
     # Test shape
     assert q_tensor.ndim == 3
     assert q_tensor.shape[0] == 2
@@ -259,7 +206,7 @@ def test_build_basis_change_tensor() -> None:
     old_q = crandn(2, 3, 4)
     new_q = crandn(2, 7, 5)
     old_m = crandn(4, 5)
-    basis_change = _build_basis_change_tensor(old_q, new_q, old_m)
+    basis_change = build_basis_change_tensor(old_q, new_q, old_m)
     assert basis_change.ndim == 2
     assert basis_change.shape[0] == 3
     assert basis_change.shape[1] == 7
@@ -280,14 +227,14 @@ def test_local_update() -> None:
     mps.set_canonical_form(0)
     ref_mps = deepcopy(mps)
     mpo = random_mpo([(2, 2, 1, 3), (2, 2, 3, 4), (2, 2, 4, 1)])
-    canon_sites, left_envs = _prepare_canonical_site_tensors(mps, mpo)
+    canon_sites, left_envs = prepare_canonical_site_tensors(mps, mpo)
     ref_canon_sites = deepcopy(canon_sites)
     right_block = np.eye(5).reshape(5, 1, 5)
     site = 2
     right_m_block = np.eye(5)
     sim_params = PhysicsSimParams(observables=[], elapsed_time=1)
     # Perform the local update
-    result = _local_update(
+    result = local_update(
         mps, mpo, left_envs, right_block, canon_sites, site, right_m_block, sim_params, numiter_lanczos=25
     )
     # General Change Check
@@ -301,92 +248,6 @@ def test_local_update() -> None:
     assert len(result) == 2
     assert result[0].shape == (3, 6)
     assert result[1].shape == (6, 4, 6)
-
-
-def test_right_svd() -> None:
-    """Test that the svd produces the correct shapes and tensors."""
-    tensor = crandn(2, 3, 4)
-    u_tensor, s_vec, v_matrix = _right_svd(tensor)
-    # Check shapes
-    assert u_tensor.shape[0] == 2
-    assert u_tensor.shape[1] == 3
-    assert v_matrix.shape[1] == 4
-    assert u_tensor.shape[2] == s_vec.shape[0]
-    assert s_vec.shape[0] == v_matrix.shape[0]
-    # Check that u_tensor is unitary
-    iden = np.eye(u_tensor.shape[2])
-    result = np.tensordot(u_tensor, u_tensor.conj(), axes=([0, 1], [0, 1]))
-    assert np.allclose(result, iden)
-    # Check that v_matrix is unitary
-    iden = np.eye(v_matrix.shape[1])
-    result = v_matrix.conj().T @ v_matrix
-    assert np.allclose(result, iden)
-    # Check that svd = tensor
-    contr = np.tensordot(u_tensor, np.diag(s_vec) @ v_matrix, axes=(2, 0))
-    assert np.allclose(contr, tensor)
-
-
-def test_truncated_right_svd_thresh() -> None:
-    """Test that the tensor is correctly truncated."""
-    # Placeholder
-    measurements = [Observable("z", site) for site in range(0)]
-    sim_params = PhysicsSimParams(
-        measurements,
-        elapsed_time=0.2,
-        dt=0.1,
-        sample_timesteps=True,
-        num_traj=1,
-        max_bond_dim=4,
-        threshold=0.2,
-        order=1,
-    )
-    s_vector_i = np.array([1, 0.5, 0.1, 0.01])
-    u_tensor_i, _ = _right_qr(crandn(2, 3, 4))
-    v_matrix_i, _ = np.linalg.qr(crandn(4, 4))
-    tensor = np.tensordot(u_tensor_i, np.diag(s_vector_i) @ v_matrix_i, axes=(2, 0))
-
-    # Thus the values 0.1 and 0.01 should be truncated
-    u_tensor, s_vector, v_matrix = _truncated_right_svd(tensor, sim_params)
-    # Check shapes
-    assert u_tensor.shape[0] == 2
-    assert u_tensor.shape[1] == 3
-    assert v_matrix.shape[1] == 4
-    assert u_tensor.shape[2] == 2
-    assert v_matrix.shape[0] == 2
-    assert s_vector.shape[0] == 2
-    assert np.allclose(s_vector, s_vector_i[:2])
-
-
-def test_truncated_right_svd_maxbd() -> None:
-    """Test that the tensor is correctly truncated."""
-    # Placeholder
-    measurements = [Observable("z", site) for site in range(0)]
-    sim_params = PhysicsSimParams(
-        measurements,
-        elapsed_time=0.2,
-        dt=0.1,
-        sample_timesteps=True,
-        num_traj=1,
-        max_bond_dim=3,
-        threshold=1e-4,
-        order=1,
-    )
-
-    s_vector_i = np.array([1, 0.5, 0.1, 0.01])
-    u_tensor_i, _ = _right_qr(crandn(2, 3, 4))
-    v_matrix_i, _ = np.linalg.qr(crandn(4, 4))
-    tensor = np.tensordot(u_tensor_i, np.diag(s_vector_i) @ v_matrix_i, axes=(2, 0))
-
-    # Thus the value 0.01 should be truncated
-    u_tensor, s_vector, v_matrix = _truncated_right_svd(tensor, sim_params)
-    # Check shapes
-    assert u_tensor.shape[0] == 2
-    assert u_tensor.shape[1] == 3
-    assert v_matrix.shape[1] == 4
-    assert u_tensor.shape[2] == sim_params.max_bond_dim
-    assert sim_params.max_bond_dim == v_matrix.shape[0]
-    assert sim_params.max_bond_dim == s_vector.shape[0]
-    assert np.allclose(s_vector, s_vector_i[: sim_params.max_bond_dim])
 
 
 def test_truncate_no_truncation() -> None:

--- a/tests/core/methods/test_decompositions.py
+++ b/tests/core/methods/test_decompositions.py
@@ -127,7 +127,7 @@ def test_truncated_right_svd_thresh() -> None:
     tensor = np.tensordot(u_tensor_i, np.diag(s_vector_i) @ v_matrix_i, axes=(2, 0))
 
     # Thus the values 0.1 and 0.01 should be truncated
-    u_tensor, s_vector, v_matrix = truncated_right_svd(tensor, sim_params)
+    u_tensor, s_vector, v_matrix = truncated_right_svd(tensor, sim_params.threshold, sim_params.max_bond_dim)
     # Check shapes
     assert u_tensor.shape[0] == 2
     assert u_tensor.shape[1] == 3
@@ -158,7 +158,7 @@ def test_truncated_right_svd_maxbd() -> None:
     tensor = np.tensordot(u_tensor_i, np.diag(s_vector_i) @ v_matrix_i, axes=(2, 0))
 
     # Thus the value 0.01 should be truncated
-    u_tensor, s_vector, v_matrix = truncated_right_svd(tensor, sim_params)
+    u_tensor, s_vector, v_matrix = truncated_right_svd(tensor, sim_params.threshold, sim_params.max_bond_dim)
     # Check shapes
     assert u_tensor.shape[0] == 2
     assert u_tensor.shape[1] == 3

--- a/tests/core/methods/test_decompositions.py
+++ b/tests/core/methods/test_decompositions.py
@@ -1,16 +1,27 @@
+# Copyright (c) 2025 Chair for Design Automation, TUM
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Tests for decompositions.
+
+This module tests the left and right qr and svd decompositions.
+"""
+
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
-from numpy.typing import NDArray
 
-
-from mqt.yaqs.core.methods.decompositions import (
-    left_qr,
-    right_qr,
-    right_svd,
-    truncated_right_svd
-)
 import numpy as np
 
 from mqt.yaqs.core.data_structures.simulation_parameters import Observable, PhysicsSimParams
+from mqt.yaqs.core.methods.decompositions import left_qr, right_qr, right_svd, truncated_right_svd
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
 
 def crandn(
     size: int | tuple[int, ...], *args: int, seed: np.random.Generator | int | None = None
@@ -136,6 +147,7 @@ def test_truncated_right_svd_thresh() -> None:
     assert v_matrix.shape[0] == 2
     assert s_vector.shape[0] == 2
     assert np.allclose(s_vector, s_vector_i[:2])
+
 
 def test_truncated_right_svd_maxbd() -> None:
     """Test that the tensor is correctly truncated."""

--- a/tests/core/methods/test_decompositions.py
+++ b/tests/core/methods/test_decompositions.py
@@ -1,0 +1,169 @@
+from typing import TYPE_CHECKING
+from numpy.typing import NDArray
+
+
+from mqt.yaqs.core.methods.decompositions import (
+    left_qr,
+    right_qr,
+    right_svd,
+    truncated_right_svd
+)
+import numpy as np
+
+from mqt.yaqs.core.data_structures.simulation_parameters import Observable, PhysicsSimParams
+
+def crandn(
+    size: int | tuple[int, ...], *args: int, seed: np.random.Generator | int | None = None
+) -> NDArray[np.complex128]:
+    """Draw random samples from the standard complex normal distribution.
+
+    Args:
+        size (int |Tuple[int,...]): The size/shape of the output array.
+        *args (int): Additional dimensions for the output array.
+        seed (Generator | int): The seed for the random number generator.
+
+    Returns:
+        NDArray[np.complex128]: The array of random complex numbers.
+    """
+    if isinstance(size, int) and len(args) > 0:
+        size = (size, *list(args))
+    elif isinstance(size, int):
+        size = (size,)
+    rng = np.random.default_rng(seed)
+    # 1/sqrt(2) is a normalization factor
+    return (rng.standard_normal(size) + 1j * rng.standard_normal(size)) / np.sqrt(2)
+
+
+def test_right_qr() -> None:
+    """Tests the right qr decomposition.
+
+    Ensures that it produces tensors of the correct shape and a unitary tensor.
+    Also checks that the decomposition is actually the original tensor.
+    """
+    shape = (2, 3, 4)
+    tensor = crandn(shape)
+    q_tensor, r_matrix = right_qr(tensor)
+    assert q_tensor.ndim == 3
+    assert r_matrix.ndim == 2
+    assert q_tensor.shape[0] == shape[0]
+    assert q_tensor.shape[1] == shape[1]
+    assert r_matrix.shape[1] == shape[2]
+    assert q_tensor.shape[2] == r_matrix.shape[0]
+    # Check that q_tensor is unitary
+    iden = np.eye(q_tensor.shape[2])
+    q_matrix = q_tensor.reshape(q_tensor.shape[0] * q_tensor.shape[1], -1)
+    assert np.allclose(q_matrix.conj().T @ q_matrix, iden)
+    # Check that qr = tensor
+    contr = np.tensordot(q_tensor, r_matrix, axes=(2, 0))
+    assert np.allclose(contr, tensor)
+
+
+def test_left_qr() -> None:
+    """Tests the left qr decomposition.
+
+    Ensures that it produces tensors of the correct shape and a unitary tensor.
+    Also checks that the decomposition is actually the original tensor.
+    """
+    shape = (2, 3, 4)
+    tensor = crandn(shape)
+    q_tensor, r_matrix = left_qr(tensor)
+    assert q_tensor.ndim == 3
+    assert r_matrix.ndim == 2
+    assert q_tensor.shape[0] == shape[0]
+    assert q_tensor.shape[2] == shape[2]
+    assert r_matrix.shape[0] == shape[1]
+    assert q_tensor.shape[1] == r_matrix.shape[1]
+    # Check that q_tensor is unitary
+    iden = np.eye(q_tensor.shape[1])
+    q_matrix = q_tensor.transpose(0, 2, 1)
+    q_matrix = q_matrix.reshape(-1, q_tensor.shape[1])
+    assert np.allclose(q_matrix.T.conj() @ q_matrix, iden)
+    # Check that qr = tensor
+    contr = np.tensordot(q_tensor, r_matrix, axes=(1, 1))
+    contr = contr.transpose(0, 2, 1)
+    assert np.allclose(contr, tensor)
+
+
+def test_right_svd() -> None:
+    """Test that the svd produces the correct shapes and tensors."""
+    tensor = crandn(2, 3, 4)
+    u_tensor, s_vec, v_matrix = right_svd(tensor)
+    # Check shapes
+    assert u_tensor.shape[0] == 2
+    assert u_tensor.shape[1] == 3
+    assert v_matrix.shape[1] == 4
+    assert u_tensor.shape[2] == s_vec.shape[0]
+    assert s_vec.shape[0] == v_matrix.shape[0]
+    # Check that u_tensor is unitary
+    iden = np.eye(u_tensor.shape[2])
+    result = np.tensordot(u_tensor, u_tensor.conj(), axes=([0, 1], [0, 1]))
+    assert np.allclose(result, iden)
+    # Check that v_matrix is unitary
+    iden = np.eye(v_matrix.shape[1])
+    result = v_matrix.conj().T @ v_matrix
+    assert np.allclose(result, iden)
+    # Check that svd = tensor
+    contr = np.tensordot(u_tensor, np.diag(s_vec) @ v_matrix, axes=(2, 0))
+    assert np.allclose(contr, tensor)
+
+
+def test_truncated_right_svd_thresh() -> None:
+    """Test that the tensor is correctly truncated."""
+    # Placeholder
+    measurements = [Observable("z", site) for site in range(0)]
+    sim_params = PhysicsSimParams(
+        measurements,
+        elapsed_time=0.2,
+        dt=0.1,
+        sample_timesteps=True,
+        num_traj=1,
+        max_bond_dim=4,
+        threshold=0.2,
+        order=1,
+    )
+    s_vector_i = np.array([1, 0.5, 0.1, 0.01])
+    u_tensor_i, _ = right_qr(crandn(2, 3, 4))
+    v_matrix_i, _ = np.linalg.qr(crandn(4, 4))
+    tensor = np.tensordot(u_tensor_i, np.diag(s_vector_i) @ v_matrix_i, axes=(2, 0))
+
+    # Thus the values 0.1 and 0.01 should be truncated
+    u_tensor, s_vector, v_matrix = truncated_right_svd(tensor, sim_params)
+    # Check shapes
+    assert u_tensor.shape[0] == 2
+    assert u_tensor.shape[1] == 3
+    assert v_matrix.shape[1] == 4
+    assert u_tensor.shape[2] == 2
+    assert v_matrix.shape[0] == 2
+    assert s_vector.shape[0] == 2
+    assert np.allclose(s_vector, s_vector_i[:2])
+
+def test_truncated_right_svd_maxbd() -> None:
+    """Test that the tensor is correctly truncated."""
+    # Placeholder
+    measurements = [Observable("z", site) for site in range(0)]
+    sim_params = PhysicsSimParams(
+        measurements,
+        elapsed_time=0.2,
+        dt=0.1,
+        sample_timesteps=True,
+        num_traj=1,
+        max_bond_dim=3,
+        threshold=1e-4,
+        order=1,
+    )
+
+    s_vector_i = np.array([1, 0.5, 0.1, 0.01])
+    u_tensor_i, _ = right_qr(crandn(2, 3, 4))
+    v_matrix_i, _ = np.linalg.qr(crandn(4, 4))
+    tensor = np.tensordot(u_tensor_i, np.diag(s_vector_i) @ v_matrix_i, axes=(2, 0))
+
+    # Thus the value 0.01 should be truncated
+    u_tensor, s_vector, v_matrix = truncated_right_svd(tensor, sim_params)
+    # Check shapes
+    assert u_tensor.shape[0] == 2
+    assert u_tensor.shape[1] == 3
+    assert v_matrix.shape[1] == 4
+    assert u_tensor.shape[2] == sim_params.max_bond_dim
+    assert sim_params.max_bond_dim == v_matrix.shape[0]
+    assert sim_params.max_bond_dim == s_vector.shape[0]
+    assert np.allclose(s_vector, s_vector_i[: sim_params.max_bond_dim])


### PR DESCRIPTION
## Description

This pull requests adds an SVD "truncation" to the end of the stochastic process. This sweep allows the bond dimensions to decrease, but is set with a low enough thresold and no maximum bond dimension such that it allows the MPS to naturally change shape following noise.

Additionally, several functions from the BUG implementation were moved to more general locations to be used throughout.


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
