### PR TITLE
Added orthogonality center tracker + truncate() does not change orthogonality center anymore

### DIFF
--- a/src/mqt/yaqs/circuits/circuit_tjm.py
+++ b/src/mqt/yaqs/circuits/circuit_tjm.py
@@ -199,7 +199,7 @@ def apply_two_qubit_gate(state: MPS, node: DAGOpNode, sim_params: StrongSimParam
         short_state, short_mpo, window = apply_window(state, mpo, first_site, last_site, window_size)
         dynamic_tdvp(short_state, short_mpo, sim_params)
         state.orthogonality_center = window[0] + short_state.orthogonality_center - window_size
-        
+
     else:
         window_size = 1
         short_state, short_mpo, window = apply_window(state, mpo, first_site, last_site, window_size)

--- a/src/mqt/yaqs/circuits/circuit_tjm.py
+++ b/src/mqt/yaqs/circuits/circuit_tjm.py
@@ -198,10 +198,13 @@ def apply_two_qubit_gate(state: MPS, node: DAGOpNode, sim_params: StrongSimParam
         window_size = 1 if state.write_max_bond_dim() < sim_params.max_bond_dim else 0
         short_state, short_mpo, window = apply_window(state, mpo, first_site, last_site, window_size)
         dynamic_tdvp(short_state, short_mpo, sim_params)
+        state.orthogonality_center = window[0] + short_state.orthogonality_center - window_size
+        
     else:
         window_size = 1
         short_state, short_mpo, window = apply_window(state, mpo, first_site, last_site, window_size)
         two_site_tdvp(short_state, short_mpo, sim_params)
+        state.orthogonality_center = window[0] + short_state.orthogonality_center - 1
 
     # Replace the updated tensors back into the full state.
     for i in range(window[0], window[1] + 1):

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -205,7 +205,8 @@ class MPS:
         ------
         ValueError: target_dim must be at least current bond dim.
         """
-        L = self.length
+
+        length = self.length
 
         # enlarge tensors
         for i, tensor in enumerate(self.tensors):
@@ -215,13 +216,13 @@ class MPS:
             if i == 0:
                 left_target = 1
             else:
-                exp_left = min(i, L - i)          # bond index = i‑1
+                exp_left = min(i, length - i)          # bond index = i‑1
                 left_target = min(target_dim, 2 ** exp_left)
 
-            if i == L - 1:
+            if i == length - 1:
                 right_target = 1
             else:
-                exp_right = min(i + 1, L - 1 - i) # bond index = i
+                exp_right = min(i + 1, length - 1 - i) # bond index = i
                 right_target = min(target_dim, 2 ** exp_right)
 
 

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -411,6 +411,22 @@ class MPS:
 
             self.flip_network()
 
+
+        # if self.length != 1:
+        #     for i, tensor in enumerate(self.tensors[:-1]):
+        #         _, _, v_mat = truncated_right_svd(tensor, threshold, max_bond_dim)
+        #         # Pull v into left leg of next tensor.
+        #         new_next = np.tensordot(v_mat, self.tensors[i + 1], axes=(1, 1))
+        #         new_next = new_next.transpose(1, 0, 2)
+        #         self.tensors[i + 1] = new_next
+        #         # Pull v^dag into current tensor.
+        #         self.tensors[i] = np.tensordot(
+        #             self.tensors[i],
+        #             v_mat.conj(),  # No transpose, put correct axes instead
+        #             axes=(2, 1),
+        #         )
+            
+
     def scalar_product(self, other: MPS, site: int | None = None) -> np.complex128:
         """Compute the scalar (inner) product between two Matrix Product States (MPS).
 

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -188,11 +188,13 @@ class MPS:
             self.pad_bond_dimension(pad)
 
     def pad_bond_dimension(self, target_dim: int) -> None:
-        """Pad bond dimension.
+        """
+        Enlarge every internal bond up to
+            min(target_dim, 2**exp)
+        where exp = min(bond_index+1, L-1-bond_index).
 
-        Pads the bond dimensions of each tensor in the MPS so that the internal bond
-        dimensions are at least target_dim. For the first tensor the left bond dimension
-        remains 1, and for the last tensor the right bond dimension remains 1.
+        The first tensor keeps a left bond of 1, the last tensor a right bond of 1.
+        After padding the state is renormalised (canonicalised).
 
         Parameters
         ----------
@@ -201,26 +203,39 @@ class MPS:
 
         Raises:
         ------
-        ValueError: If target_dim is smaller than any existing bond dimension.
+        ValueError: target_dim must be at least current bond dim.
         """
+        L = self.length
+
+        # enlarge tensors
         for i, tensor in enumerate(self.tensors):
-            # Tensor shape is (physical_dim, chi_left, chi_right)
-            phys, chi_left, chi_right = tensor.shape
+            phys, chi_l, chi_r = tensor.shape
 
-            # Determine desired bond dimensions
-            new_left = chi_left if i == 0 else target_dim
-            new_right = chi_right if i == self.length - 1 else target_dim
+            # compute the desired dimension for the bond left of site i
+            if i == 0:
+                left_target = 1
+            else:
+                exp_left = min(i, L - i)          # bond index = i‑1
+                left_target = min(target_dim, 2 ** exp_left)
 
-            # Check if the target dimensions are valid
-            if chi_left > new_left or chi_right > new_right:
-                msg = "Target bond dim must be at least as large as the current bond dim."
-                raise ValueError(msg)
+            if i == L - 1:
+                right_target = 1
+            else:
+                exp_right = min(i + 1, L - 1 - i) # bond index = i
+                right_target = min(target_dim, 2 ** exp_right)
 
-            # Create a new tensor with zeros and copy the original data into the appropriate block
-            new_tensor = np.zeros((phys, new_left, new_right), dtype=tensor.dtype)
-            new_tensor[:, :chi_left, :chi_right] = tensor
 
+            # sanity‑check — we must never shrink an existing bond
+            if chi_l > left_target or chi_r > right_target:
+                raise ValueError("Target bond dim must be at least current bond dim.")
+
+            # allocate new tensor and copy original data
+            new_tensor = np.zeros((phys, left_target, right_target), dtype=tensor.dtype)
+            new_tensor[:, :chi_l, :chi_r] = tensor
             self.tensors[i] = new_tensor
+        # renormalise the state
+        self.normalize()             
+
 
     def write_max_bond_dim(self) -> int:
         """Write max bond dim.

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -411,20 +411,6 @@ class MPS:
 
             self.flip_network()
 
-        # if self.length != 1:
-        #     for i, tensor in enumerate(self.tensors[:-1]):
-        #         _, _, v_mat = truncated_right_svd(tensor, threshold, max_bond_dim)
-        #         # Pull v into left leg of next tensor.
-        #         new_next = np.tensordot(v_mat, self.tensors[i + 1], axes=(1, 1))
-        #         new_next = new_next.transpose(1, 0, 2)
-        #         self.tensors[i + 1] = new_next
-        #         # Pull v^dag into current tensor.
-        #         self.tensors[i] = np.tensordot(
-        #             self.tensors[i],
-        #             v_mat.conj(),  # No transpose, put correct axes instead
-        #             axes=(2, 1),
-        #         )
-
     def scalar_product(self, other: MPS, site: int | None = None) -> np.complex128:
         """Compute the scalar (inner) product between two Matrix Product States (MPS).
 

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -390,7 +390,6 @@ class MPS:
 
         if self.length != 1:
             for i in range(orthogonality_center):
-                self.tensors[i].shape
                 u_tensor, s_vec, v_mat = truncated_right_svd(self.tensors[i], threshold, max_bond_dim)
                 self.tensors[i] = u_tensor
 

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -373,7 +373,7 @@ class MPS:
             self.flip_network()
             self.orthogonality_center = 0
 
-        else:
+        elif form == "A":
             self.orthogonality_center = self.length - 1
 
     def truncate(self, threshold: float = 1e-12, max_bond_dim: int | None = None) -> None:

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -188,8 +188,7 @@ class MPS:
             self.pad_bond_dimension(pad)
 
     def pad_bond_dimension(self, target_dim: int) -> None:
-        """
-        Enlarge every internal bond up to
+        """Enlarge every internal bond up to
             min(target_dim, 2**exp)
         where exp = min(bond_index+1, L-1-bond_index).
 
@@ -205,7 +204,6 @@ class MPS:
         ------
         ValueError: target_dim must be at least current bond dim.
         """
-
         length = self.length
 
         # enlarge tensors
@@ -216,27 +214,26 @@ class MPS:
             if i == 0:
                 left_target = 1
             else:
-                exp_left = min(i, length - i)          # bond index = i‑1
-                left_target = min(target_dim, 2 ** exp_left)
+                exp_left = min(i, length - i)  # bond index = i‑1
+                left_target = min(target_dim, 2**exp_left)
 
             if i == length - 1:
                 right_target = 1
             else:
-                exp_right = min(i + 1, length - 1 - i) # bond index = i
-                right_target = min(target_dim, 2 ** exp_right)
-
+                exp_right = min(i + 1, length - 1 - i)  # bond index = i
+                right_target = min(target_dim, 2**exp_right)
 
             # sanity‑check — we must never shrink an existing bond
             if chi_l > left_target or chi_r > right_target:
-                raise ValueError("Target bond dim must be at least current bond dim.")
+                msg = "Target bond dim must be at least current bond dim."
+                raise ValueError(msg)
 
             # allocate new tensor and copy original data
             new_tensor = np.zeros((phys, left_target, right_target), dtype=tensor.dtype)
             new_tensor[:, :chi_l, :chi_r] = tensor
             self.tensors[i] = new_tensor
         # renormalise the state
-        self.normalize()             
-
+        self.normalize()
 
     def write_max_bond_dim(self) -> int:
         """Write max bond dim.

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -386,10 +386,10 @@ class MPS:
             max_bond_dim: The maximum bond dimension allowed. Default None.
 
         """
-        ortho_center = self.orthogonality_center
+        orthogonality_center = self.orthogonality_center
 
         if self.length != 1:
-            for i in range(ortho_center):
+            for i in range(orthogonality_center):
                 self.tensors[i].shape
                 u_tensor, s_vec, v_mat = truncated_right_svd(self.tensors[i], threshold, max_bond_dim)
                 self.tensors[i] = u_tensor
@@ -401,8 +401,8 @@ class MPS:
 
             self.flip_network()
 
-            ortho_center_flipped = self.length - 1 - ortho_center
-            for i in range(ortho_center_flipped):
+            orthogonality_center_flipped = self.length - 1 - orthogonality_center
+            for i in range(orthogonality_center_flipped):
                 u_tensor, s_vec, v_mat = truncated_right_svd(self.tensors[i], threshold, max_bond_dim)
                 self.tensors[i] = u_tensor
                 # Pull v into left leg of next tensor.

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -317,7 +317,7 @@ class MPS:
         """
         if self.orthogonality_center > 0:
             self.orthogonality_center = current_orthogonality_center - 1
-        
+
         self.flip_network()
         self.shift_orthogonality_center_right(self.length - current_orthogonality_center - 1, decomposition)
         self.flip_network()
@@ -332,7 +332,6 @@ class MPS:
             orthogonality_center (int): site of matrix MPS around which we normalize
             decomposition: Type of decomposition. Default QR.
         """
-
         self.orthogonality_center = orthogonality_center
 
         # Sweep to the right
@@ -373,7 +372,7 @@ class MPS:
         if form == "B":
             self.flip_network()
             self.orthogonality_center = 0
-        
+
         else:
             self.orthogonality_center = self.length - 1
 
@@ -391,13 +390,13 @@ class MPS:
 
         if self.length != 1:
             for i in range(ortho_center):
-                old_shape = self.tensors[i].shape
+                self.tensors[i].shape
                 u_tensor, s_vec, v_mat = truncated_right_svd(self.tensors[i], threshold, max_bond_dim)
                 self.tensors[i] = u_tensor
 
                 # Pull v into left leg of next tensor.
                 bond = np.diag(s_vec) @ v_mat
-                new_next = oe.contract("ij, kjl ->kil", bond, self.tensors[i+1])
+                new_next = oe.contract("ij, kjl ->kil", bond, self.tensors[i + 1])
                 self.tensors[i + 1] = new_next
 
             self.flip_network()
@@ -408,12 +407,10 @@ class MPS:
                 self.tensors[i] = u_tensor
                 # Pull v into left leg of next tensor.
                 bond = np.diag(s_vec) @ v_mat
-                new_next = oe.contract("ij, kjl ->kil", bond, self.tensors[i+1])
+                new_next = oe.contract("ij, kjl ->kil", bond, self.tensors[i + 1])
                 self.tensors[i + 1] = new_next
 
             self.flip_network()
-
-
 
     def scalar_product(self, other: MPS, site: int | None = None) -> np.complex128:
         """Compute the scalar (inner) product between two Matrix Product States (MPS).

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -386,9 +386,7 @@ class MPS:
             max_bond_dim: The maximum bond dimension allowed. Default None.
 
         """
-
         orthogonality_center = self.orthogonality_center
-
 
         if self.length != 1:
             for i in range(orthogonality_center):

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -411,7 +411,6 @@ class MPS:
 
             self.flip_network()
 
-
         # if self.length != 1:
         #     for i, tensor in enumerate(self.tensors[:-1]):
         #         _, _, v_mat = truncated_right_svd(tensor, threshold, max_bond_dim)
@@ -425,7 +424,6 @@ class MPS:
         #             v_mat.conj(),  # No transpose, put correct axes instead
         #             axes=(2, 1),
         #         )
-            
 
     def scalar_product(self, other: MPS, site: int | None = None) -> np.complex128:
         """Compute the scalar (inner) product between two Matrix Product States (MPS).

--- a/src/mqt/yaqs/core/methods/tdvp.py
+++ b/src/mqt/yaqs/core/methods/tdvp.py
@@ -563,14 +563,13 @@ def two_site_tdvp(
     # Only a single sweep is needed for circuits
     if isinstance(sim_params, (WeakSimParams, StrongSimParams)):
         state.tensors[i], state.tensors[i + 1] = split_mps_tensor(merged_tensor, "right", sim_params, dynamic=dynamic)
-        state.orthogonality_center = state.length - 1 # state.length - 1 if "right", state.length -2 if "left"
+        state.orthogonality_center = state.length - 1  # state.length - 1 if "right", state.length -2 if "left"
         return
 
     state.tensors[i], state.tensors[i + 1] = split_mps_tensor(merged_tensor, "left", sim_params, dynamic=dynamic)
     right_blocks[i] = update_right_environment(
         state.tensors[i + 1], state.tensors[i + 1], hamiltonian.tensors[i + 1], right_blocks[i + 1]
     )
-    
 
     # Right-to-left sweep.
     for i in reversed(range(num_sites - 2)):

--- a/src/mqt/yaqs/core/methods/tdvp.py
+++ b/src/mqt/yaqs/core/methods/tdvp.py
@@ -447,6 +447,7 @@ def single_site_tdvp(
     )
 
     if isinstance(sim_params, (WeakSimParams, StrongSimParams)):
+        state.orthogonality_center = state.length - 1
         return
 
     # Right-to-left sweep: Update sites 1 to L-1.
@@ -476,6 +477,7 @@ def single_site_tdvp(
             0.5 * sim_params.dt,
             numiter_lanczos,
         )
+        state.orthogonality_center = 0
 
 
 def two_site_tdvp(
@@ -561,12 +563,14 @@ def two_site_tdvp(
     # Only a single sweep is needed for circuits
     if isinstance(sim_params, (WeakSimParams, StrongSimParams)):
         state.tensors[i], state.tensors[i + 1] = split_mps_tensor(merged_tensor, "right", sim_params, dynamic=dynamic)
+        state.orthogonality_center = state.length - 1 # state.length - 1 if "right", state.length -2 if "left"
         return
 
     state.tensors[i], state.tensors[i + 1] = split_mps_tensor(merged_tensor, "left", sim_params, dynamic=dynamic)
     right_blocks[i] = update_right_environment(
         state.tensors[i + 1], state.tensors[i + 1], hamiltonian.tensors[i + 1], right_blocks[i + 1]
     )
+    
 
     # Right-to-left sweep.
     for i in reversed(range(num_sites - 2)):
@@ -587,3 +591,4 @@ def two_site_tdvp(
         right_blocks[i] = update_right_environment(
             state.tensors[i + 1], state.tensors[i + 1], hamiltonian.tensors[i + 1], right_blocks[i + 1]
         )
+    state.orthogonality_center = 0

--- a/tests/circuits/test_circuit_tjm.py
+++ b/tests/circuits/test_circuit_tjm.py
@@ -207,7 +207,7 @@ def test_apply_two_qubit_gate() -> None:
             np.testing.assert_allclose(np.abs(element), 1, atol=1e-16)
         else:
             np.testing.assert_allclose(np.abs(element), 0, atol=1e-16)
-    
+
 
 def test_circuit_tjm_strong() -> None:
     """Test the circuit_tjm function for strong simulation.

--- a/tests/circuits/test_circuit_tjm.py
+++ b/tests/circuits/test_circuit_tjm.py
@@ -199,6 +199,7 @@ def test_apply_two_qubit_gate() -> None:
     sim_params = StrongSimParams([observable], num_traj, max_bond_dim, threshold, window_size)
     copy.deepcopy(mps0.tensors)
     apply_two_qubit_gate(mps0, node, sim_params)
+    assert mps0.orthogonality_center == 2
     mps0.normalize(decomposition="SVD")
     assert mps0.orthogonality_center == 0
     for i, element in enumerate(mps0.to_vec()):

--- a/tests/circuits/test_circuit_tjm.py
+++ b/tests/circuits/test_circuit_tjm.py
@@ -170,6 +170,7 @@ def test_apply_window() -> None:
     assert window == [0, 3]
     assert short_state.length == 4
     assert short_mpo.length == 4
+    assert short_state.orthogonality_center == 0
 
 
 def test_apply_two_qubit_gate() -> None:
@@ -199,12 +200,13 @@ def test_apply_two_qubit_gate() -> None:
     copy.deepcopy(mps0.tensors)
     apply_two_qubit_gate(mps0, node, sim_params)
     mps0.normalize(decomposition="SVD")
+    assert mps0.orthogonality_center == 0
     for i, element in enumerate(mps0.to_vec()):
         if i == 11:
             np.testing.assert_allclose(np.abs(element), 1, atol=1e-16)
         else:
             np.testing.assert_allclose(np.abs(element), 0, atol=1e-16)
-
+    
 
 def test_circuit_tjm_strong() -> None:
     """Test the circuit_tjm function for strong simulation.

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -804,23 +804,23 @@ def test_convert_to_vector_fidelity_long_range() -> None:
     np.testing.assert_allclose(1, np.abs(np.vdot(state_vector, tdvp_state)) ** 2)
 
 
-@pytest.mark.parametrize("length, target", [(6, 16), (7, 7), (9, 8), (10, 3)])
+@pytest.mark.parametrize(("length", "target"), [(6, 16), (7, 7), (9, 8), (10, 3)])
 def test_pad_shapes_and_centre(length: int, target: int) -> None:
     """Test that pad_bond_dimension correctly pads the MPS and preserves invariants.
 
-        * the state’s norm is unchanged
-        * the orthogonality-centre index is [0]
-        * every virtual leg has the expected size
-          ( powers-of-two “staircase” capped by target_dim )
+    * the state's norm is unchanged
+    * the orthogonality-centre index is [0]
+    * every virtual leg has the expected size
+      ( powers-of-two "staircase" capped by target_dim )
     """
-    mps = MPS(length=length, state="zeros")          # all bonds = 1
-    norm_before   = mps.norm()
+    mps = MPS(length=length, state="zeros")  # all bonds = 1
+    norm_before = mps.norm()
 
     mps.pad_bond_dimension(target)
 
     # invariants
     assert np.isclose(mps.norm(), norm_before, atol=1e-12)
-    assert mps.check_canonical_form()[0] == 0 
+    assert mps.check_canonical_form()[0] == 0
 
     # expected staircase
     for i, T in enumerate(mps.tensors):
@@ -830,17 +830,17 @@ def test_pad_shapes_and_centre(length: int, target: int) -> None:
         if i == 0:
             left_expected = 1
         else:
-            exp_left     = min(i, L - i)          
-            left_expected = min(target, 2 ** exp_left)
+            exp_left = min(i, L - i)
+            left_expected = min(target, 2**exp_left)
 
         # right (bond i)
         if i == length - 1:
             right_expected = 1
         else:
-            exp_right      = min(i + 1, L - 1 - i)
-            right_expected = min(target, 2 ** exp_right)
+            exp_right = min(i + 1, L - 1 - i)
+            right_expected = min(target, 2**exp_right)
 
-        assert chi_l == left_expected,  f"site {i}: left {chi_l} vs {left_expected}"
+        assert chi_l == left_expected, f"site {i}: left {chi_l} vs {left_expected}"
         assert chi_r == right_expected, f"site {i}: right {chi_r} vs {right_expected}"
 
 
@@ -851,10 +851,10 @@ def test_pad_raises_on_shrink() -> None:
     bond must raise a ValueError.
     """
     mps = MPS(length=5, state="zeros")
-    mps.pad_bond_dimension(4)      # enlarge first
+    mps.pad_bond_dimension(4)  # enlarge first
 
     with pytest.raises(ValueError, match="Target bond dim must be at least current bond dim"):
-        mps.pad_bond_dimension(2)   # would shrink - must fail
+        mps.pad_bond_dimension(2)  # would shrink - must fail
 
 
 @pytest.mark.parametrize("center", [0, 1, 2, 3])

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -804,8 +804,8 @@ def test_convert_to_vector_fidelity_long_range() -> None:
     np.testing.assert_allclose(1, np.abs(np.vdot(state_vector, tdvp_state)) ** 2)
 
 
-@pytest.mark.parametrize("L, target", [(6, 16), (7, 7), (9, 8), (10, 3)])
-def test_pad_shapes_and_centre(L: int, target: int) -> None:
+@pytest.mark.parametrize("length, target", [(6, 16), (7, 7), (9, 8), (10, 3)])
+def test_pad_shapes_and_centre(length: int, target: int) -> None:
     """Test that pad_bond_dimension correctly pads the MPS and preserves invariants.
 
         * the state’s norm is unchanged
@@ -813,7 +813,7 @@ def test_pad_shapes_and_centre(L: int, target: int) -> None:
         * every virtual leg has the expected size
           ( powers-of-two “staircase” capped by target_dim )
     """
-    mps = MPS(length=L, state="zeros")          # all bonds = 1
+    mps = MPS(length=length, state="zeros")          # all bonds = 1
     norm_before   = mps.norm()
 
     mps.pad_bond_dimension(target)
@@ -826,7 +826,7 @@ def test_pad_shapes_and_centre(L: int, target: int) -> None:
     for i, T in enumerate(mps.tensors):
         _, chi_l, chi_r = T.shape
 
-        # left (bond i‑1)
+        # left (bond i - 1)
         if i == 0:
             left_expected = 1
         else:
@@ -834,7 +834,7 @@ def test_pad_shapes_and_centre(L: int, target: int) -> None:
             left_expected = min(target, 2 ** exp_left)
 
         # right (bond i)
-        if i == L - 1:
+        if i == length - 1:
             right_expected = 1
         else:
             exp_right      = min(i + 1, L - 1 - i)
@@ -854,7 +854,7 @@ def test_pad_raises_on_shrink() -> None:
     mps.pad_bond_dimension(4)      # enlarge first
 
     with pytest.raises(ValueError, match="Target bond dim must be at least current bond dim"):
-        mps.pad_bond_dimension(2)   # would shrink – must fail
+        mps.pad_bond_dimension(2)   # would shrink - must fail
 
 
 @pytest.mark.parametrize("center", [0, 1, 2, 3])

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -804,47 +804,57 @@ def test_convert_to_vector_fidelity_long_range() -> None:
     np.testing.assert_allclose(1, np.abs(np.vdot(state_vector, tdvp_state)) ** 2)
 
 
-def test_padded_mps() -> None:
-    """Test that MPS initializes with correct padding.
+@pytest.mark.parametrize("L, target", [(6, 16), (7, 7), (9, 8), (10, 3)])
+def test_pad_shapes_and_centre(L: int, target: int) -> None:
+    """Test that pad_bond_dimension correctly pads the MPS and preserves invariants.
 
-    This test creates an MPS with padded bond dimensions.
+        * the state’s norm is unchanged
+        * the orthogonality-centre index is [0]
+        * every virtual leg has the expected size
+          ( powers-of-two “staircase” capped by target_dim )
     """
-    length = 4
-    pdim = 2
-    mps = MPS(length=length, physical_dimensions=[pdim] * length, pad=2)
+    mps = MPS(length=L, state="zeros")          # all bonds = 1
+    norm_before   = mps.norm()
 
-    assert mps.length == length
-    assert len(mps.tensors) == length
-    assert all(d == pdim for d in mps.physical_dimensions)
+    mps.pad_bond_dimension(target)
 
-    for i, tensor in enumerate(mps.tensors):
-        if i != 0 and i != mps.length - 1:
-            assert tensor.ndim == 3
-            assert tensor.shape[0] == pdim
-            assert tensor.shape[1] == 2
-            assert tensor.shape[2] == 2
-        elif i == 0:
-            assert tensor.ndim == 3
-            assert tensor.shape[0] == pdim
-            assert tensor.shape[1] == 1
-            assert tensor.shape[2] == 2
-        elif i == mps.length - 1:
-            assert tensor.ndim == 3
-            assert tensor.shape[0] == pdim
-            assert tensor.shape[1] == 2
-            assert tensor.shape[2] == 1
+    # invariants
+    assert np.isclose(mps.norm(), norm_before, atol=1e-12)
+    assert mps.check_canonical_form()[0] == 0 
+
+    # expected staircase
+    for i, T in enumerate(mps.tensors):
+        _, chi_l, chi_r = T.shape
+
+        # left (bond i‑1)
+        if i == 0:
+            left_expected = 1
+        else:
+            exp_left     = min(i, L - i)          
+            left_expected = min(target, 2 ** exp_left)
+
+        # right (bond i)
+        if i == L - 1:
+            right_expected = 1
+        else:
+            exp_right      = min(i + 1, L - 1 - i)
+            right_expected = min(target, 2 ** exp_right)
+
+        assert chi_l == left_expected,  f"site {i}: left {chi_l} vs {left_expected}"
+        assert chi_r == right_expected, f"site {i}: right {chi_r} vs {right_expected}"
 
 
-def test_padded_mps_error() -> None:
-    """Test that MPS initializes with correct padding.
+def test_pad_raises_on_shrink() -> None:
+    """Test that pad_bond_dimension raises a ValueError when trying to shrink the bond dimension.
 
-    This test creates an MPS with incorrect padding
+    Calling pad_bond_dimension with a *smaller* target than an existing
+    bond must raise a ValueError.
     """
-    length = 4
-    pdim = 2
-    mps = MPS(length=length, physical_dimensions=[pdim] * length, pad=2)
-    with pytest.raises(ValueError, match=r"Target bond dim must be at least as large as the current bond dim."):
-        mps.pad_bond_dimension(1)
+    mps = MPS(length=5, state="zeros")
+    mps.pad_bond_dimension(4)      # enlarge first
+
+    with pytest.raises(ValueError, match="Target bond dim must be at least current bond dim"):
+        mps.pad_bond_dimension(2)   # would shrink – must fail
 
 
 @pytest.mark.parametrize("center", [0, 1, 2, 3])

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -22,6 +22,7 @@ import copy
 from typing import TYPE_CHECKING
 
 import numpy as np
+import opt_einsum as oe
 import pytest
 from qiskit.circuit import QuantumCircuit
 from scipy.stats import unitary_group
@@ -504,8 +505,9 @@ def test_set_canonical_form(desired_center: int) -> None:
 def test_normalize() -> None:
     """Test that normalize brings an MPS to unit norm without changing tensor ranks.
 
-    This test normalizes an MPS (using 'B' normalization) and verifies that the overall norm is 1 and
-    that all tensors remain rank-3.
+    This test normalizes an MPS (using 'B' normalization) and verifies that the overall norm is 1, 
+    the orthogonality center is 0 and that all tensors remain rank-3. The same for 'A' normalization, 
+    where the orthogonality center is length - 1.
     """
     length = 4
     pdim = 2
@@ -517,6 +519,13 @@ def test_normalize() -> None:
 
     mps.normalize(form="B")
     assert np.isclose(mps.norm(), 1)
+    assert mps.orthogonality_center == 0
+    for tensor in mps.tensors:
+        assert tensor.ndim == 3
+
+    mps.normalize(form="A")
+    assert np.isclose(mps.norm(), 1)
+    assert mps.orthogonality_center == length - 1
     for tensor in mps.tensors:
         assert tensor.ndim == 3
 
@@ -838,30 +847,69 @@ def test_padded_mps_error() -> None:
         mps.pad_bond_dimension(1)
 
 
-def test_truncate_no_truncation() -> None:
-    """Tests the truncation of an MPS, when no truncation should happen."""
-    shapes = [(2, 1, 4)] + [(2, 4, 4)] * 3 + [(2, 4, 1)]
+
+@pytest.mark.parametrize("center", [0, 1, 2, 3])
+def test_truncate_preserves_orthogonality_center_and_canonicity(center: int) -> None:
+    """Test that truncation preserves the orthogonality center and canonicity.
+
+    This test checks that after truncation, the orthogonality center remains unchanged.
+    """
+
+    # build a simple MPS of length 4
+    shapes = [(2, 1, 4)] + [(2, 4, 4)] * 2 + [(2, 4, 1)]
     mps = random_mps(shapes)
-    mps.set_canonical_form(0)
-    ref_mps = copy.deepcopy(mps)
-    # Perform truncation
-    mps.truncate(threshold=1e-16, max_bond_dim=10)
-    # Check that the MPS is unchanged
-    mps.check_if_valid_mps()
-    vector = mps.to_vec()
-    ref_vector = ref_mps.to_vec()
-    assert np.allclose(vector, ref_vector)
+    # set an arbitrary initial center
+    mps.set_canonical_form(center)
+    # record the full state-vector for fidelity check
+    before_vec = mps.to_vec()
+    # record the center and canonical-split
+    before_center = mps.check_canonical_form()[0]
+    assert before_center == center
+
+    # do a "no-real" truncation (tiny threshold, generous max bond)
+    mps.truncate(threshold=1e-16, max_bond_dim=100)
+    after_center = mps.check_canonical_form()[0]
+    assert after_center == before_center
+
+    # fidelity of state stays unity
+    after_vec = mps.to_vec()
+    overlap = np.abs(np.vdot(before_vec, after_vec)) ** 2
+    assert np.isclose(overlap, 1.0, atol=1e-12)
+
+    # also check left/right canonicity around that center
+    L = mps.length
+    for i in range(before_center):
+        # left-canonical test
+        A = mps.tensors[i]
+        conjA = np.conj(A)
+        gram = oe.contract("ijk, ijl->kl", conjA, A)
+        # identity on the i-th right bond
+        assert np.allclose(gram, np.eye(gram.shape[0]), atol=1e-12)
+    for i in range(before_center + 1, L):
+        # right-canonical test
+        A = mps.tensors[i]
+        conjA = np.conj(A)
+        gram = oe.contract("ijk, ilk->jl", A, conjA)
+        assert np.allclose(gram, np.eye(gram.shape[0]), atol=1e-12)
 
 
-def test_truncate_truncation() -> None:
-    """Tests the truncation of an MPS, when truncation should happen."""
-    shapes = [(2, 1, 4)] + [(2, 4, 4)] * 3 + [(2, 4, 1)]
+def test_truncate_reduces_bond_dimensions_and_truncates() -> None:
+    """Test that truncation reduces bond dimensions and truncates the MPS.
+
+    This test creates an MPS with large bond dimensions and then truncates it to a smaller size.
+    """
+
+    # build an MPS with initially large bonds
+    shapes = [(2, 1, 8)] + [(2, 8, 8)] * 3 + [(2, 8, 1)]
     mps = random_mps(shapes)
-    mps.set_canonical_form(0)
-    # Perform truncation
-    mps.truncate(threshold=0.1, max_bond_dim=3)
-    # Check that the MPS is truncated
+    # put it into a known canonical form
+    mps.set_canonical_form(2)
+    # perform a truncation that will cut back to max_bond=3
+    mps.truncate(threshold=0.0, max_bond_dim=3)
+
+    # check validity and that every bond dim <= 3
     mps.check_if_valid_mps()
-    for tensor in mps.tensors:
-        assert tensor.shape[1] <= 3
-        assert tensor.shape[2] <= 3
+    for T in mps.tensors:
+        _, bond_left, bond_right = T.shape
+        assert bond_left <= 3
+        assert bond_right <= 3

--- a/tests/core/data_structures/test_networks.py
+++ b/tests/core/data_structures/test_networks.py
@@ -505,8 +505,8 @@ def test_set_canonical_form(desired_center: int) -> None:
 def test_normalize() -> None:
     """Test that normalize brings an MPS to unit norm without changing tensor ranks.
 
-    This test normalizes an MPS (using 'B' normalization) and verifies that the overall norm is 1, 
-    the orthogonality center is 0 and that all tensors remain rank-3. The same for 'A' normalization, 
+    This test normalizes an MPS (using 'B' normalization) and verifies that the overall norm is 1,
+    the orthogonality center is 0 and that all tensors remain rank-3. The same for 'A' normalization,
     where the orthogonality center is length - 1.
     """
     length = 4
@@ -853,7 +853,6 @@ def test_truncate_preserves_orthogonality_center_and_canonicity(center: int) -> 
 
     This test checks that after truncation, the orthogonality center remains unchanged.
     """
-
     # build a simple MPS of length 4
     shapes = [(2, 1, 4)] + [(2, 4, 4)] * 2 + [(2, 4, 1)]
     mps = random_mps(shapes)
@@ -897,7 +896,6 @@ def test_truncate_reduces_bond_dimensions_and_truncates() -> None:
 
     This test creates an MPS with large bond dimensions and then truncates it to a smaller size.
     """
-
     # build an MPS with initially large bonds
     shapes = [(2, 1, 8)] + [(2, 8, 8)] * 3 + [(2, 8, 1)]
     mps = random_mps(shapes)


### PR DESCRIPTION
## Description


Added a orthogonality center tracker to the MPS class and to any function that affects the change of the orthogonality center: __init__, set_canonical_form(), shift_orthogonality_center_right(), shift_orthogonality_center_left(), flip_network(), truncate()

Additionally truncate() does not change the orthogonality center anymore.

Fixes #(issue) <!--- Replace (issue) with the issue number that is fixed by this pull request. -->

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x ] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
