### PR TITLE
updated circuit tjm, set standard svd threshold to 1e-17

### DIFF
--- a/src/mqt/yaqs/circuits/circuit_tjm.py
+++ b/src/mqt/yaqs/circuits/circuit_tjm.py
@@ -25,7 +25,7 @@ from ..core.data_structures.networks import MPO, MPS
 from ..core.data_structures.simulation_parameters import WeakSimParams
 from ..core.methods.dissipation import apply_dissipation
 from ..core.methods.stochastic_process import stochastic_process
-from ..core.methods.tdvp import local_dynamic_tdvp
+from ..core.methods.tdvp import local_dynamic_tdvp, two_site_tdvp
 from .utils.dag_utils import convert_dag_to_tensor_algorithm
 
 if TYPE_CHECKING:
@@ -194,7 +194,11 @@ def apply_two_qubit_gate(state: MPS, node: DAGOpNode, sim_params: StrongSimParam
 
     window_size = 1
     short_state, short_mpo, window = apply_window(state, mpo, first_site, last_site, window_size)
-    local_dynamic_tdvp(short_state, short_mpo, sim_params)
+    if np.abs(first_site - last_site) == 1:
+        # Apply two-site TDVP for nearest-neighbor gates.
+        two_site_tdvp(short_state, short_mpo, sim_params)
+    else:
+        local_dynamic_tdvp(short_state, short_mpo, sim_params)
 
     # Replace the updated tensors back into the full state.
     for i in range(window[0], window[1] + 1):

--- a/src/mqt/yaqs/core/data_structures/networks.py
+++ b/src/mqt/yaqs/core/data_structures/networks.py
@@ -301,7 +301,7 @@ class MPS:
         if decomposition == "QR":
             site_tensor, bond_tensor = right_qr(tensor)
         elif decomposition == "SVD":
-            site_tensor, s_vec, v_mat = truncated_right_svd(tensor, threshold=1e-15, max_bond_dim=None)
+            site_tensor, s_vec, v_mat = truncated_right_svd(tensor, threshold=1e-17, max_bond_dim=None)
             bond_tensor = np.diag(s_vec) @ v_mat
         self.tensors[current_orthogonality_center] = site_tensor
 


### PR DESCRIPTION
## Description

Circuit TJM uses 2TDVP for nearest neighbour gates now and local dynamicTDVP for long range gates. 


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
