### PR TITLE
fixed bug in equivalence checking of long-range gates

### DIFF
--- a/src/mqt/yaqs/circuits/utils/mpo_utils.py
+++ b/src/mqt/yaqs/circuits/utils/mpo_utils.py
@@ -110,9 +110,8 @@ def apply_gate(
         assert gate.sites[1] in {site0, site1}, "Two-qubit gate must be on the correct pair of sites."
 
     # For nearest-neighbor gates (theta.ndim == 6)
-    assert theta.ndim == 6
-    if conjugate:
-        theta = np.transpose(theta, (3, 4, 2, 0, 1, 5))
+    assert theta.ndim == 6, "Expected theta to have 6 dimensions, got %d" % theta.ndim
+    theta = np.transpose(theta, (3, 4, 2, 0, 1, 5))
 
     if gate.name == "I":
         pass  # Identity gate, no action needed.
@@ -299,19 +298,18 @@ def apply_long_range_layer(mpo: MPO, dag1: DAGCircuit, dag2: DAGCircuit, thresho
                 tensor4 = np.transpose(mpo.tensors[overall_site + 1], (0, 2, 1, 3))
                 theta = oe.contract("abcd,edfg,chij,fjkl->aebhikgl", tensor1, tensor2, tensor3, tensor4)
             else:
-                mpo.rotate()
+                mpo.rotate(conjugate=True)
                 tensor1 = np.transpose(gate_mpo.tensors[site_gate_mpo], (0, 2, 1, 3))
                 tensor2 = np.transpose(gate_mpo.tensors[site_gate_mpo + 1], (0, 2, 1, 3))
                 tensor3 = np.transpose(mpo.tensors[overall_site], (0, 2, 1, 3))
                 tensor4 = np.transpose(mpo.tensors[overall_site + 1], (0, 2, 1, 3))
-                theta = oe.contract("abcd,edfg,chij,fjkl->aebhikgl", tensor1, tensor2, tensor3, tensor4)
-                mpo.rotate()
-
-            theta = apply_temporal_zone(theta, dag1, [overall_site, overall_site + 1], conjugate=False)
-            theta = apply_temporal_zone(theta, dag2, [overall_site, overall_site + 1], conjugate=True)
+                theta = oe.contract('abcd,edfg,chij,fjkl->ikhbaelg', tensor1, tensor2, tensor3, tensor4)
+                mpo.rotate(conjugate=True)
 
             dims = theta.shape
             theta = np.reshape(theta, (dims[0], dims[1], dims[2] * dims[3], dims[4], dims[5], dims[6] * dims[7]))
+            theta = apply_temporal_zone(theta, dag1, [overall_site, overall_site + 1], conjugate=False)
+            theta = apply_temporal_zone(theta, dag2, [overall_site, overall_site + 1], conjugate=True)
             mpo.tensors[overall_site], mpo.tensors[overall_site + 1] = decompose_theta(theta, threshold)
 
             gate_mpo.tensors[site_gate_mpo] = None
@@ -324,11 +322,11 @@ def apply_long_range_layer(mpo: MPO, dag1: DAGCircuit, dag2: DAGCircuit, thresho
                 tensor2 = np.transpose(mpo.tensors[overall_site], (0, 2, 1, 3))
                 theta = oe.contract("abcd,cefg->abefdg", tensor1, tensor2)
             else:
-                mpo.rotate()
+                mpo.rotate(conjugate=True)
                 tensor1 = np.transpose(gate_mpo.tensors[site_gate_mpo], (0, 2, 1, 3))
                 tensor2 = np.transpose(mpo.tensors[overall_site], (0, 2, 1, 3))
                 theta = oe.contract("abcd,cefg->febagd", tensor1, tensor2)
-                mpo.rotate()
+                mpo.rotate(conjugate=True)
 
             dims = theta.shape
             theta = np.reshape(theta, (dims[0], dims[1] * dims[2], dims[3], dims[4] * dims[5]))

--- a/src/mqt/yaqs/circuits/utils/mpo_utils.py
+++ b/src/mqt/yaqs/circuits/utils/mpo_utils.py
@@ -110,7 +110,7 @@ def apply_gate(
         assert gate.sites[1] in {site0, site1}, "Two-qubit gate must be on the correct pair of sites."
 
     # For nearest-neighbor gates (theta.ndim == 6)
-    assert theta.ndim == 6, "Expected theta to have 6 dimensions, got %d" % theta.ndim
+    assert theta.ndim == 6, f"Expected theta to have 6 dimensions, got {theta.ndim}"
     theta = np.transpose(theta, (3, 4, 2, 0, 1, 5))
 
     if gate.name == "I":

--- a/src/mqt/yaqs/circuits/utils/mpo_utils.py
+++ b/src/mqt/yaqs/circuits/utils/mpo_utils.py
@@ -303,7 +303,7 @@ def apply_long_range_layer(mpo: MPO, dag1: DAGCircuit, dag2: DAGCircuit, thresho
                 tensor2 = np.transpose(gate_mpo.tensors[site_gate_mpo + 1], (0, 2, 1, 3))
                 tensor3 = np.transpose(mpo.tensors[overall_site], (0, 2, 1, 3))
                 tensor4 = np.transpose(mpo.tensors[overall_site + 1], (0, 2, 1, 3))
-                theta = oe.contract('abcd,edfg,chij,fjkl->ikhbaelg', tensor1, tensor2, tensor3, tensor4)
+                theta = oe.contract("abcd,edfg,chij,fjkl->ikhbaelg", tensor1, tensor2, tensor3, tensor4)
                 mpo.rotate(conjugate=True)
 
             dims = theta.shape

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -925,9 +925,9 @@ class CZ(BaseGate):
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         # Generator: π/4 (I-Z ⊗ I-Z)
         self.generator = [(np.pi / 4) * np.array([[0, 0], [0, 2]]), np.array([[1, -1], [-1, 1]])]
+        self.mpo = extend_gate(self.tensor, self.sites)
         if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
             self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
-
 
 class CPhase(BaseGate):
     """Class representing the controlled phase (CPhase) gate.
@@ -958,9 +958,34 @@ class CPhase(BaseGate):
         self.theta = params[0]
         mat = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, np.exp(1j * self.theta)]])
         super().__init__(mat)
+
+
+    def set_sites(self, *sites: int | list[int]) -> None:
+        """Sets the sites for the gate.
+
+        Args:
+            *sites (int): Variable-length argument list specifying site indices.
+
+        Raises:
+            ValueError: If the number of sites does not match the interaction level of the gate.
+        """
+        sites_list = []
+        for s in sites:
+            if isinstance(s, int):
+                sites_list.append(s)
+            else:
+                sites_list.extend(s)
+
+        if len(sites_list) != self.interaction:
+            msg = f"Number of sites {len(sites_list)} must be equal to the interaction level {self.interaction}"
+            raise ValueError(msg)
+
+        self.sites = sites_list
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.generator = [(self.theta / 2) * np.array([[1, 0], [0, -1]]), np.array([[1, 0], [0, 0]])]
-
+        self.mpo = extend_gate(self.tensor, self.sites)
+        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
+            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 class SWAP(BaseGate):
     """Class representing the SWAP gate.
@@ -983,8 +1008,32 @@ class SWAP(BaseGate):
         """Initializes the SWAP gate."""
         mat = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
         super().__init__(mat)
-        self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
 
+    def set_sites(self, *sites: int | list[int]) -> None:
+        """Sets the sites for the gate.
+
+        Args:
+            *sites (int): Variable-length argument list specifying site indices.
+
+        Raises:
+            ValueError: If the number of sites does not match the interaction level of the gate.
+        """
+        sites_list = []
+        for s in sites:
+            if isinstance(s, int):
+                sites_list.append(s)
+            else:
+                sites_list.extend(s)
+
+        if len(sites_list) != self.interaction:
+            msg = f"Number of sites {len(sites_list)} must be equal to the interaction level {self.interaction}"
+            raise ValueError(msg)
+
+        self.sites = sites_list
+        self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
+        self.mpo = extend_gate(self.tensor, self.sites)
+        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
+            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 class Rxx(BaseGate):
     """Class representing a two-qubit rotation gate about the xx-axis.
@@ -1021,8 +1070,34 @@ class Rxx(BaseGate):
             [-1j * np.sin(self.theta / 2), 0, 0, np.cos(self.theta / 2)],
         ])
         super().__init__(mat)
+    
+
+    def set_sites(self, *sites: int | list[int]) -> None:
+        """Sets the sites for the gate.
+
+        Args:
+            *sites (int): Variable-length argument list specifying site indices.
+
+        Raises:
+            ValueError: If the number of sites does not match the interaction level of the gate.
+        """
+        sites_list = []
+        for s in sites:
+            if isinstance(s, int):
+                sites_list.append(s)
+            else:
+                sites_list.extend(s)
+
+        if len(sites_list) != self.interaction:
+            msg = f"Number of sites {len(sites_list)} must be equal to the interaction level {self.interaction}"
+            raise ValueError(msg)
+
+        self.sites = sites_list
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.generator = [(self.theta / 2) * np.array([[0, 1], [1, 0]]), np.array([[0, 1], [1, 0]])]
+        self.mpo = extend_gate(self.tensor, self.sites)
+        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
+            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 
 class Ryy(BaseGate):
@@ -1060,8 +1135,33 @@ class Ryy(BaseGate):
             [1j * np.sin(self.theta / 2), 0, 0, np.cos(self.theta / 2)],
         ])
         super().__init__(mat)
+
+    def set_sites(self, *sites: int | list[int]) -> None:
+        """Sets the sites for the gate.
+
+        Args:
+            *sites (int): Variable-length argument list specifying site indices.
+
+        Raises:
+            ValueError: If the number of sites does not match the interaction level of the gate.
+        """
+        sites_list = []
+        for s in sites:
+            if isinstance(s, int):
+                sites_list.append(s)
+            else:
+                sites_list.extend(s)
+
+        if len(sites_list) != self.interaction:
+            msg = f"Number of sites {len(sites_list)} must be equal to the interaction level {self.interaction}"
+            raise ValueError(msg)
+
+        self.sites = sites_list
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.generator = [(self.theta / 2) * np.array([[0, -1j], [1j, 0]]), np.array([[0, -1j], [1j, 0]])]
+        self.mpo = extend_gate(self.tensor, self.sites)
+        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
+            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 
 class Rzz(BaseGate):
@@ -1099,8 +1199,33 @@ class Rzz(BaseGate):
             [0, 0, 0, np.cos(self.theta / 2) - 1j * np.sin(self.theta / 2)],
         ])
         super().__init__(mat)
+
+    def set_sites(self, *sites: int | list[int]) -> None:
+        """Sets the sites for the gate.
+
+        Args:
+            *sites (int): Variable-length argument list specifying site indices.
+
+        Raises:
+            ValueError: If the number of sites does not match the interaction level of the gate.
+        """
+        sites_list = []
+        for s in sites:
+            if isinstance(s, int):
+                sites_list.append(s)
+            else:
+                sites_list.extend(s)
+
+        if len(sites_list) != self.interaction:
+            msg = f"Number of sites {len(sites_list)} must be equal to the interaction level {self.interaction}"
+            raise ValueError(msg)
+
+        self.sites = sites_list
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.generator = [(self.theta / 2) * np.array([[1, 0], [0, -1]]), np.array([[1, 0], [0, -1]])]
+        self.mpo = extend_gate(self.tensor, self.sites)
+        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
+            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 
 class XX(BaseGate):

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -30,7 +30,7 @@ def split_tensor(tensor: NDArray[np.complex128]) -> list[NDArray[np.complex128]]
     """Splits a two-qubit tensor into two tensors using Singular Value Decomposition (SVD).
 
     Args:
-        tensor (NDArray[np.complex128]): A 4-dimensional tensor with shape (2, 2, 2, 2).
+        tensor: A 4-dimensional tensor with shape (2, 2, 2, 2).
 
     Returns:
         list[NDArray[np.complex128]]: A list containing two tensors resulting from the split.
@@ -69,8 +69,8 @@ def extend_gate(tensor: NDArray[np.complex128], sites: list[int]) -> MPO:
     between specified sites.
 
     Args:
-        tensor (NDArray[np.complex128]): The input gate tensor to be extended.
-        sites (list[int]): A list of site indices where the gate tensor is to be applied.
+        tensor: The input gate tensor to be extended.
+        sites: A list of site indices where the gate tensor is to be applied.
 
     Returns:
         MPO: The resulting Matrix Product Operator with the gate tensor extended over the specified sites.
@@ -124,11 +124,11 @@ class BaseGate:
     """Base class representing a quantum gate.
 
     Attributes:
-        name (str): The name of the gate.
-        matrix (NDArray[np.complex128]): The matrix representation of the gate.
-        interaction (int): The interaction type or level of the gate.
-        tensor (NDArray[np.complex128]): The tensor representation of the gate.
-        generator (NDArray[np.complex128] | list[NDArray[np.complex128]]): The generator(s) for the gate.
+        name: The name of the gate.
+        matrix: The matrix representation of the gate.
+        interaction: The interaction type or level of the gate.
+        tensor: The tensor representation of the gate.
+        generator: The generator(s) for the gate.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -146,7 +146,7 @@ class BaseGate:
         """Initializes a BaseGate instance with the given matrix.
 
         Args:
-            mat (NDArray[np.complex128]): The matrix representation of the gate.
+            mat: The matrix representation of the gate.
 
         Raises:
             ValueError: If the matrix is not square.
@@ -170,7 +170,7 @@ class BaseGate:
         """Sets the sites for the gate.
 
         Args:
-            *sites (int): Variable-length argument list specifying site indices.
+            *sites: Variable-length argument list specifying site indices.
 
         Raises:
             ValueError: If the number of sites does not match the interaction level of the gate.
@@ -194,7 +194,7 @@ class BaseGate:
         """Adds two gates together.
 
         Args:
-            other (BaseGate): The gate to be added.
+            other: The gate to be added.
 
         Raises:
             ValueError: If the gates have different interaction levels.
@@ -211,7 +211,7 @@ class BaseGate:
         """Subtracts one gate from another.
 
         Args:
-            other (BaseGate): The gate to be subtracted.
+            other: The gate to be subtracted.
 
         Raises:
             ValueError: If the gates have different interaction levels.
@@ -228,7 +228,7 @@ class BaseGate:
         """Multiplies two gates or scales a gate by a scalar.
 
         Args:
-            other (BaseGate | complex): The gate or scalar to multiply.
+            other: The gate or scalar to multiply.
 
         Raises:
             ValueError: If the gates have different interaction levels (when multiplying two gates).
@@ -248,7 +248,7 @@ class BaseGate:
         """Multiplies a scalar or another gate with this gate (right multiplication).
 
         Args:
-            other (BaseGate | complex): The gate or scalar to multiply.
+            other: The gate or scalar to multiply.
 
         Returns:
             BaseGate: A new gate representing the product.
@@ -368,7 +368,7 @@ class BaseGate:
         """Returns the RY gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameter.
+            params: The rotation angle parameter.
 
         Returns:
             Ry: An instance of the RY gate.
@@ -380,7 +380,7 @@ class BaseGate:
         """Returns the RZ gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameter.
+            params: The rotation angle parameter.
 
         Returns:
             Rz: An instance of the RZ gate.
@@ -392,7 +392,7 @@ class BaseGate:
         """Returns the Phase gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameter.
+            params: The rotation angle parameter.
 
         Returns:
             Phase: An instance of the Phase gate.
@@ -404,7 +404,7 @@ class BaseGate:
         """Returns the U3 gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameters.
+            params: The rotation angle parameters.
 
         Returns:
             U3: An instance of the U3 gate.
@@ -434,7 +434,7 @@ class BaseGate:
         """Returns the CPhase gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameter.
+            params: The rotation angle parameter.
 
         Returns:
             CPhase: An instance of the CPhase gate.
@@ -455,7 +455,7 @@ class BaseGate:
         """Returns the RXX gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameter.
+            params: The rotation angle parameter.
 
         Returns:
             Rxx: An instance of the RXX gate.
@@ -467,7 +467,7 @@ class BaseGate:
         """Returns the RYY gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameter.
+            params: The rotation angle parameter.
 
         Returns:
             Ryy: An instance of the RYY gate.
@@ -479,7 +479,7 @@ class BaseGate:
         """Returns the RZZ gate.
 
         Args:
-            params (list[Parameter]): The rotation angle parameter.
+            params: The rotation angle parameter.
 
         Returns:
             Rzz: An instance of the RZZ gate.
@@ -491,10 +491,10 @@ class X(BaseGate):
     """Class representing the Pauli-X (NOT) gate.
 
     Attributes:
-        name (str): The name of the gate ("x").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
+        name: The name of the gate ("x").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -513,10 +513,10 @@ class Y(BaseGate):
     """Class representing the Pauli-Y gate.
 
     Attributes:
-        name (str): The name of the gate ("y").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
+        name: The name of the gate ("y").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -535,10 +535,10 @@ class Z(BaseGate):
     """Class representing the Pauli-Z gate.
 
     Attributes:
-        name (str): The name of the gate ("z").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
+        name: The name of the gate ("z").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -557,10 +557,10 @@ class H(BaseGate):
     """Class representing the Hadamard (H) gate.
 
     Attributes:
-        name (str): The name of the gate ("h").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
+        name: The name of the gate ("h").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -579,10 +579,10 @@ class Destroy(BaseGate):
     """Class representing the Destroy (annihilation) gate.
 
     Attributes:
-        name (str): The name of the gate ("destroy").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
+        name: The name of the gate ("destroy").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -601,10 +601,10 @@ class Create(BaseGate):
     """Class representing the Create (creation) gate.
 
     Attributes:
-        name (str): The name of the gate ("create").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
+        name: The name of the gate ("create").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -623,10 +623,10 @@ class Id(BaseGate):
     """Class representing the identity (Id) gate.
 
     Attributes:
-        name (str): The name of the gate ("id").
-        matrix (NDArray[np.complex128]): The 2x2 identity matrix.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
+        name: The name of the gate ("id").
+        matrix: The 2x2 identity matrix.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -645,10 +645,10 @@ class SX(BaseGate):
     """Class representing the square-root X (SX) gate.
 
     Attributes:
-        name (str): The name of the gate ("sx").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
+        name: The name of the gate ("sx").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -667,11 +667,11 @@ class Rx(BaseGate):
     """Class representing a rotation gate about the x-axis.
 
     Attributes:
-        name (str): The name of the gate ("rx").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
-        theta (Parameter): The rotation angle parameter.
+        name: The name of the gate ("rx").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+        theta: The rotation angle parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -699,11 +699,11 @@ class Ry(BaseGate):
     """Class representing a rotation gate about the y-axis.
 
     Attributes:
-        name (str): The name of the gate ("ry").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
-        theta (Parameter): The rotation angle parameter.
+        name: The name of the gate ("ry").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+        theta: The rotation angle parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -731,11 +731,11 @@ class Rz(BaseGate):
     """Class representing a rotation gate about the z-axis.
 
     Attributes:
-        name (str): The name of the gate ("rz").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
-        theta (Parameter): The rotation angle parameter.
+        name: The name of the gate ("rz").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+        theta: The rotation angle parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -763,11 +763,11 @@ class Phase(BaseGate):
     """Class representing a phase gate.
 
     Attributes:
-        name (str): The name of the gate ("p").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
-        theta (Parameter): The phase angle parameter.
+        name: The name of the gate ("p").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+        theta: The phase angle parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -792,13 +792,13 @@ class U3(BaseGate):
     """Class representing a U3 gate.
 
     Attributes:
-        name (str): The name of the gate ("u").
-        matrix (NDArray[np.complex128]): The 2x2 matrix representation of the gate.
-        interaction (int): The interaction level (1 for single-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation of the gate (same as the matrix).
-        theta (float): The first rotation parameter.
-        phi (float): The second rotation parameter.
-        lam (float): The third rotation parameter.
+        name: The name of the gate ("u").
+        matrix: The 2x2 matrix representation of the gate.
+        interaction: The interaction level (1 for single-qubit gates).
+        tensor: The tensor representation of the gate (same as the matrix).
+        theta: The first rotation parameter.
+        phi: The second rotation parameter.
+        lam: The third rotation parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -829,13 +829,13 @@ class CX(BaseGate):
     """Class representing the controlled-NOT (CX) gate.
 
     Attributes:
-        name (str): The name of the gate ("cx").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
-        generator (list[NDArray[np.complex128]]): The generator for the gate.
+        name: The name of the gate ("cx").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
+        generator: The generator for the gate.
         mpo: An MPO representation generated from the gate tensor.
-        sites (list[int]): The control and target sites.
+        sites: The control and target sites.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -853,7 +853,7 @@ class CX(BaseGate):
         """Sets the sites for the gate.
 
         Args:
-            *sites (int): Variable-length argument list specifying site indices.
+            *sites: Variable-length argument list specifying site indices.
 
         Raises:
             ValueError: If the number of sites does not match the interaction level of the gate.
@@ -882,12 +882,12 @@ class CZ(BaseGate):
     """Class representing the controlled-Z (CZ) gate.
 
     Attributes:
-        name (str): The name of the gate ("cz").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
-        generator (list[NDArray[np.complex128]]): The generator for the gate.
-        sites (list[int]): The control and target sites.
+        name: The name of the gate ("cz").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
+        generator: The generator for the gate.
+        sites: The control and target sites.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -905,7 +905,7 @@ class CZ(BaseGate):
         """Sets the sites for the gate.
 
         Args:
-            *sites (int): Variable-length argument list specifying site indices.
+            *sites: Variable-length argument list specifying site indices.
 
         Raises:
             ValueError: If the number of sites does not match the interaction level of the gate.
@@ -934,13 +934,13 @@ class CPhase(BaseGate):
     """Class representing the controlled phase (CPhase) gate.
 
     Attributes:
-        name (str): The name of the gate ("cp").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
-        generator (list[NDArray[np.complex128]]): The generator for the gate.
-        sites (list[int]): The control and target sites.
-        theta (Parameter): The angle parameter.
+        name: The name of the gate ("cp").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
+        generator: The generator for the gate.
+        sites: The control and target sites.
+        theta: The angle parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -964,7 +964,7 @@ class CPhase(BaseGate):
         """Sets the sites for the gate.
 
         Args:
-            *sites (int): Variable-length argument list specifying site indices.
+            *sites: Variable-length argument list specifying site indices.
 
         Raises:
             ValueError: If the number of sites does not match the interaction level of the gate.
@@ -990,11 +990,11 @@ class SWAP(BaseGate):
     """Class representing the SWAP gate.
 
     Attributes:
-        name (str): The name of the gate ("swap").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
-        sites (list[int]): The sites involved in the swap.
+        name: The name of the gate ("swap").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
+        sites: The sites involved in the swap.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -1012,7 +1012,7 @@ class SWAP(BaseGate):
         """Sets the sites for the gate.
 
         Args:
-            *sites (int): Variable-length argument list specifying site indices.
+            *sites: Variable-length argument list specifying site indices.
 
         Raises:
             ValueError: If the number of sites does not match the interaction level of the gate.
@@ -1037,13 +1037,13 @@ class Rxx(BaseGate):
     """Class representing a two-qubit rotation gate about the xx-axis.
 
     Attributes:
-        name (str): The name of the gate ("rxx").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
-        generator (list[NDArray[np.complex128]]): The generator for the gate.
-        sites (list[int]): The control and target sites.
-        theta (Parameter): The angle parameter.
+        name: The name of the gate ("rxx").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
+        generator: The generator for the gate.
+        sites: The control and target sites.
+        theta: The angle parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -1073,7 +1073,7 @@ class Rxx(BaseGate):
         """Sets the sites for the gate.
 
         Args:
-            *sites (int): Variable-length argument list specifying site indices.
+            *sites: Variable-length argument list specifying site indices.
 
         Raises:
             ValueError: If the number of sites does not match the interaction level of the gate.
@@ -1099,13 +1099,13 @@ class Ryy(BaseGate):
     """Class representing a two-qubit rotation gate about the yy-axis.
 
     Attributes:
-        name (str): The name of the gate ("ryy").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
-        generator (list[NDArray[np.complex128]]): The generator for the gate.
-        sites (list[int]): The control and target sites.
-        theta (Parameter): The angle parameter.
+        name: The name of the gate ("ryy").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
+        generator: The generator for the gate.
+        sites: The control and target sites.
+        theta: The angle parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -1135,7 +1135,7 @@ class Ryy(BaseGate):
         """Sets the sites for the gate.
 
         Args:
-            *sites (int): Variable-length argument list specifying site indices.
+            *sites: Variable-length argument list specifying site indices.
 
         Raises:
             ValueError: If the number of sites does not match the interaction level of the gate.
@@ -1161,13 +1161,13 @@ class Rzz(BaseGate):
     """Class representing a two-qubit rotation gate about the zz-axis.
 
     Attributes:
-        name (str): The name of the gate ("rzz").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
-        generator (list[NDArray[np.complex128]]): The generator for the gate.
-        sites (list[int]): The control and target sites.
-        theta (Parameter): The angle parameter.
+        name: The name of the gate ("rzz").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
+        generator: The generator for the gate.
+        sites: The control and target sites.
+        theta: The angle parameter.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -1197,7 +1197,7 @@ class Rzz(BaseGate):
         """Sets the sites for the gate.
 
         Args:
-            *sites (int): Variable-length argument list specifying site indices.
+            *sites: Variable-length argument list specifying site indices.
 
         Raises:
             ValueError: If the number of sites does not match the interaction level of the gate.
@@ -1223,12 +1223,12 @@ class XX(BaseGate):
     """Class representing an XX operation. Used for two-site correlators.
 
     Attributes:
-        name (str): The name of the gate ("xx").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
+        name: The name of the gate ("xx").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
         mpo: An MPO representation generated from the gate tensor.
-        sites (list[int]): The control and target sites.
+        sites: The control and target sites.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -1249,12 +1249,12 @@ class YY(BaseGate):
     """Class representing an YY operation. Used for two-site correlators.
 
     Attributes:
-        name (str): The name of the gate ("yy").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
+        name: The name of the gate ("yy").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
         mpo: An MPO representation generated from the gate tensor.
-        sites (list[int]): The control and target sites.
+        sites: The control and target sites.
 
     Methods:
         set_sites(*sites: int) -> None:
@@ -1275,12 +1275,12 @@ class ZZ(BaseGate):
     """Class representing an ZZ operation. Used for two-site correlators.
 
     Attributes:
-        name (str): The name of the gate ("zz").
-        matrix (NDArray[np.complex128]): The 4x4 matrix representation of the gate.
-        interaction (int): The interaction level (2 for two-qubit gates).
-        tensor (NDArray[np.complex128]): The tensor representation reshaped to (2, 2, 2, 2).
+        name: The name of the gate ("zz").
+        matrix: The 4x4 matrix representation of the gate.
+        interaction: The interaction level (2 for two-qubit gates).
+        tensor: The tensor representation reshaped to (2, 2, 2, 2).
         mpo: An MPO representation generated from the gate tensor.
-        sites (list[int]): The control and target sites.
+        sites: The control and target sites.
 
     Methods:
         set_sites(*sites: int) -> None:

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -984,8 +984,6 @@ class CPhase(BaseGate):
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.generator = [(self.theta / 2) * np.array([[1, 0], [0, -1]]), np.array([[1, 0], [0, 0]])]
         self.mpo = extend_gate(self.tensor, self.sites)
-        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
-            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 
 class SWAP(BaseGate):
@@ -1033,8 +1031,6 @@ class SWAP(BaseGate):
         self.sites = sites_list
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.mpo = extend_gate(self.tensor, self.sites)
-        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
-            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 
 class Rxx(BaseGate):
@@ -1097,8 +1093,6 @@ class Rxx(BaseGate):
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.generator = [(self.theta / 2) * np.array([[0, 1], [1, 0]]), np.array([[0, 1], [1, 0]])]
         self.mpo = extend_gate(self.tensor, self.sites)
-        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
-            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 
 class Ryy(BaseGate):
@@ -1161,8 +1155,6 @@ class Ryy(BaseGate):
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.generator = [(self.theta / 2) * np.array([[0, -1j], [1j, 0]]), np.array([[0, -1j], [1j, 0]])]
         self.mpo = extend_gate(self.tensor, self.sites)
-        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
-            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 
 class Rzz(BaseGate):
@@ -1225,8 +1217,6 @@ class Rzz(BaseGate):
         self.tensor: NDArray[np.complex128] = np.reshape(self.matrix, (2, 2, 2, 2))
         self.generator = [(self.theta / 2) * np.array([[1, 0], [0, -1]]), np.array([[1, 0], [0, -1]])]
         self.mpo = extend_gate(self.tensor, self.sites)
-        if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
-            self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
 
 class XX(BaseGate):

--- a/src/mqt/yaqs/core/libraries/gate_library.py
+++ b/src/mqt/yaqs/core/libraries/gate_library.py
@@ -929,6 +929,7 @@ class CZ(BaseGate):
         if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
             self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
+
 class CPhase(BaseGate):
     """Class representing the controlled phase (CPhase) gate.
 
@@ -959,7 +960,6 @@ class CPhase(BaseGate):
         mat = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, np.exp(1j * self.theta)]])
         super().__init__(mat)
 
-
     def set_sites(self, *sites: int | list[int]) -> None:
         """Sets the sites for the gate.
 
@@ -986,6 +986,7 @@ class CPhase(BaseGate):
         self.mpo = extend_gate(self.tensor, self.sites)
         if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
             self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
+
 
 class SWAP(BaseGate):
     """Class representing the SWAP gate.
@@ -1035,6 +1036,7 @@ class SWAP(BaseGate):
         if self.sites[1] < self.sites[0]:  # Adjust for reverse control/target
             self.tensor = np.transpose(self.tensor, (1, 0, 3, 2))
 
+
 class Rxx(BaseGate):
     """Class representing a two-qubit rotation gate about the xx-axis.
 
@@ -1070,7 +1072,6 @@ class Rxx(BaseGate):
             [-1j * np.sin(self.theta / 2), 0, 0, np.cos(self.theta / 2)],
         ])
         super().__init__(mat)
-    
 
     def set_sites(self, *sites: int | list[int]) -> None:
         """Sets the sites for the gate.

--- a/tests/circuits/circuit.qasm
+++ b/tests/circuits/circuit.qasm
@@ -1,0 +1,49 @@
+// circuit_small.qasm
+OPENQASM 2.0;
+include "qelib1.inc";
+
+// teach the parser what rzz is
+gate rzz(theta) a,b {
+    cx a,b;
+    rz(theta) b;
+    cx a,b;
+}
+
+qreg q[6];
+creg c[6];
+
+// layer 1
+ry(0.671272670484062) q[0];
+ry(0.383393090311768) q[1];
+ry(0.390761880931935) q[2];
+// entangle first three
+cx q[0],q[1];
+cx q[1],q[2];
+
+// layer 2
+ry(0.105246328897056) q[3];
+cx q[2],q[3];
+
+// layer 3
+ry(0.738872295810560) q[4];
+cx q[3],q[4];
+
+// layer 4
+ry(0.277312276421170) q[5];
+cx q[4],q[5];
+
+// now use rzz
+rzz(1.5707963267948966) q[0],q[5];
+
+// fan-in back to q0
+cx q[5],q[4];
+cx q[4],q[3];
+cx q[3],q[2];
+cx q[2],q[1];
+cx q[1],q[0];
+
+// final mixing
+ry(0.55) q[0];
+
+// seal it
+barrier q;

--- a/tests/circuits/test_equivalence_checking.py
+++ b/tests/circuits/test_equivalence_checking.py
@@ -20,10 +20,11 @@ checks for:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from qiskit import QuantumCircuit
 from qiskit.qasm2 import load
-from pathlib import Path
 
 from mqt.yaqs.circuits.equivalence_checker import run
 

--- a/tests/circuits/test_equivalence_checking.py
+++ b/tests/circuits/test_equivalence_checking.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import pytest
 from qiskit import QuantumCircuit
+from qiskit.qasm2 import load
+from pathlib import Path
 
 from mqt.yaqs.circuits.equivalence_checker import run
 
@@ -119,3 +121,16 @@ def test_long_range_non_equivalence() -> None:
 
     result = run(qc1, qc2, threshold=1e-13, fidelity=1 - 1e-13)
     assert result["equivalent"] is False, "Extra gate should break equivalence."
+
+
+def test_large_equivalence() -> None:
+    """Test large-scale equivalence.
+
+    This test creates a large quantum circuit with multiple CNOT gates, Ry gates, and an Rzz gate.
+    This should verify nearly all parts of the equivalence checking algorithm.
+    """
+    qasm_path = Path(__file__).parent / "circuit.qasm"
+    qc = load(filename=str(qasm_path))
+
+    result = run(qc, qc)
+    assert result["equivalent"] is True, "Large scale test fails. Circuits should be equivalent."


### PR DESCRIPTION
## Description

This fixes a bug in the equivalence checking of long-range gates. Some indices and order of operations were mismatched from the original transfer to YAQS from prototype code.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
